### PR TITLE
Make log files appear as binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.words.log binary


### PR DESCRIPTION
words.log files will no longer appear in diffs. 
