### PR TITLE
Fix mode that we run logging files

### DIFF
--- a/system_test/buildlog.bat
+++ b/system_test/buildlog.bat
@@ -3,7 +3,7 @@
 :loop
 if "%~1" neq "" (
   echo Logging %1 ...
-  java -jar jar/Words.jar %1 -nogui >%1.log
+  java -jar jar/Words.jar %1 -testmode >%1.log
 
   shift
   goto :loop

--- a/system_test/buildlog.sh
+++ b/system_test/buildlog.sh
@@ -2,5 +2,5 @@
 
 for prog in "$@"; do
     echo "Logging $prog ..."
-    java -jar jar/Words.jar "$prog" -nogui >"$prog.log"
+    java -jar jar/Words.jar "$prog" -testmode >"$prog.log"
 done


### PR DESCRIPTION
We had changed the parameter "nogui" to "testmode" to suppress console output, but the build file didn't have the new mode. 
