### PR TITLE
Abort Build on Test Error

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@
     <!-- report is plain, could also be xml -->
     <target name="test-unit" depends="test-compile">
         <mkdir dir="${test.report.dir}" />
-        <junit printsummary="on" fork="true" haltonfailure="no">
+        <junit printsummary="on" fork="true" haltonfailure="true">
             <classpath refid="junit.classpath" />
             <formatter type="plain" />
             <batchtest todir="${test.report.dir}">


### PR DESCRIPTION
Minor change to build.xml so that, if a JUnit test fails, ant will report BUILD FAILED.  Right now it's reporting BUILD SUCCESSFUL even if a JUnit test fails, which is misleading and might cause is to miss an test failure.  Also, if we use Travis continuous integration, a failure of a JUnit test must cause ant to report BUILD FAILED, or Travis will not reject it.

A consequence of this change is that if any unit test fails, the system tests aren't even run.  But I think that's fine.
