### PR TITLE
Enable java assertions by default for tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -88,6 +88,9 @@
     <target name="test-unit" depends="clean, test-compile">
         <mkdir dir="${test.report.dir}" />
         <junit printsummary="on" fork="true" haltonfailure="true">
+            <assertions>
+                <enable />
+            </assertions>
             <classpath refid="junit.classpath" />
             <formatter type="plain" />
             <batchtest todir="${test.report.dir}">

--- a/src/words/ast/INodeAssign.java
+++ b/src/words/ast/INodeAssign.java
@@ -17,9 +17,8 @@ public class INodeAssign extends INode {
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
 		WordsObject obj = children.get(0).eval(environment).objValue;
-		if (obj == null) {
-			throw new AssertionError("Obj should never be null here");
-		}
+		assert obj != null : "Obj was null when it shouldn't have been.";
+		
 		String propertyName = children.get(1).eval(environment).stringValue;
 		ASTValue propertyASTValue = children.get(2).eval(environment);	
 

--- a/src/words/ast/INodeRetrieveProperty.java
+++ b/src/words/ast/INodeRetrieveProperty.java
@@ -27,10 +27,8 @@ public class INodeRetrieveProperty extends INode {
 		}
 		
 		WordsObject obj = refList.objValue;
-		if (obj == null) {
-			throw new AssertionError("obj shouldn't be null");
-		}
-		
+		assert obj != null : "Obj was null when it shouldn't have been.";
+
 		ASTValue id = children.get(1).eval(environment);
 		String propName = id.stringValue;
 		

--- a/src/words/environment/WordsAction.java
+++ b/src/words/environment/WordsAction.java
@@ -15,8 +15,7 @@ public abstract class WordsAction {
 	 * Execute the action if it is expandable.
 	 */
 	public final void execute(WordsObject object, WordsEnvironment environment) throws WordsProgramException {
-		boolean flag = !isExecutable();
-		assert flag : "Attempted to execute non-executable action";
+		assert isExecutable() : "Attempted to execute non-executable action";
 		doExecute(object, environment);
 	};
 
@@ -25,8 +24,7 @@ public abstract class WordsAction {
 	 * @throws WordsRuntimeException
 	 */
 	public final LinkedList<WordsAction> expand(WordsObject object, WordsEnvironment environment) throws WordsProgramException {
-		boolean flag = !isExpandable();
-		assert flag : "Attempted to expand non-expandable action";
+		assert isExpandable() : "Attempted to expand non-expandable action";
 		return doExpand(object, environment);
 	};
 

--- a/system_test/buildlog.bat
+++ b/system_test/buildlog.bat
@@ -3,7 +3,7 @@
 :loop
 if "%~1" neq "" (
   echo Logging %1 ...
-  java -jar jar/Words.jar %1 -testmode >%1.log
+  java -enableassertions -jar jar/Words.jar %1 -testmode >%1.log
 
   shift
   goto :loop

--- a/system_test/buildlog.sh
+++ b/system_test/buildlog.sh
@@ -2,5 +2,5 @@
 
 for prog in "$@"; do
     echo "Logging $prog ..."
-    java -jar jar/Words.jar "$prog" -testmode >"$prog.log"
+    java -enableassertions -jar jar/Words.jar "$prog" -testmode >"$prog.log"
 done

--- a/system_test/test.bat
+++ b/system_test/test.bat
@@ -2,7 +2,7 @@
 
 :loop
 if "%~1" neq "" (
-  java -jar jar/Words.jar %1 -testmode > run.log.tmp
+  java -enableassertions -jar jar/Words.jar %1 -testmode > run.log.tmp
 
   fc run.log.tmp %1.log >nul 2>&1 && echo [System Test] %~n1%~x1 OK || (echo [System Test] %~n1%~x1 FAILED  Check run.log.tmp.  Aborting...  & exit 1)
   

--- a/system_test/test.sh
+++ b/system_test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for prog in "$@"; do
-    java -jar jar/Words.jar "$prog" -testmode > run.log.tmp
+    java -enableassertions -jar jar/Words.jar "$prog" -testmode > run.log.tmp
     
     if ! diff run.log.tmp "$prog.log"; then
     	echo "[System Test] ${prog##*/} FAILED  Check run.log.tmp.  Aborting..."


### PR DESCRIPTION
Hello guys,

I found that assertions in java are not enabled by default. So I suggest that we enable assertions in unit tests and system tests. Previously, the java assertions (not the junit assertions) do not really work.

I was reading the WordsAction.java, and realized that the assertions for isExecutable() and isExpandable() do not work. In fact, they appear to be incorrect and I just fixed them.

Please take a look and see if we should merge this asap.

Thanks,
Wangda
