### PR TITLE
Delay Queue Move Eval

### DIFF
--- a/src/words/ast/INodeQueueMove.java
+++ b/src/words/ast/INodeQueueMove.java
@@ -1,6 +1,5 @@
 package words.ast;
 
-import words.ast.ASTValue.ValueType;
 import words.environment.*;
 import words.exceptions.*;
 
@@ -14,7 +13,7 @@ public class INodeQueueMove extends INode {
 		ASTValue referenceObject = children.get(0).eval(environment);
 		ASTValue identifier = children.get(1).eval(environment);
 		ASTValue direction = children.get(2).eval(environment);
-		ASTValue distance = children.get(3) != null ? children.get(3).eval(environment) : new ASTValue(1);
+		AST distance = children.get(3);
 		ASTValue doNow = children.get(4) != null ? children.get(4).eval(environment) : null;
 		
 		WordsObject object;
@@ -33,8 +32,7 @@ public class INodeQueueMove extends INode {
 		
 		assert(direction.type == ASTValue.ValueType.DIRECTION) : "Expected direction";
 		
-		//TODO: Distance = 0 should create a wait method
-		WordsMove action = new WordsMove(direction.directionValue, distance.numValue);
+		WordsMove action = new WordsMove(direction.directionValue, distance);
 		
 		if (doNow == null) {
 			object.enqueueAction(action);

--- a/system_test/DelayEvalTest.words
+++ b/system_test/DelayEvalTest.words
@@ -1,0 +1,8 @@
+Fred is a thing at 0,0.
+Fred's dist is 4-3.
+
+Make Fred move left Fred's dist.
+
+Fred's dist is 1+2.
+
+Make Fred move right Fred's dist.

--- a/system_test/DelayEvalTest.words.log
+++ b/system_test/DelayEvalTest.words.log
@@ -1,0 +1,300 @@
+frame #: 1
+(0,0):
+<thing> Fred
+frame #: 2
+(-1,0):
+<thing> Fred
+frame #: 3
+(-2,0):
+<thing> Fred
+frame #: 4
+(-3,0):
+<thing> Fred
+frame #: 5
+(-2,0):
+<thing> Fred
+frame #: 6
+(-1,0):
+<thing> Fred
+frame #: 7
+(0,0):
+<thing> Fred
+frame #: 8
+(0,0):
+<thing> Fred
+frame #: 9
+(0,0):
+<thing> Fred
+frame #: 10
+(0,0):
+<thing> Fred
+frame #: 11
+(0,0):
+<thing> Fred
+frame #: 12
+(0,0):
+<thing> Fred
+frame #: 13
+(0,0):
+<thing> Fred
+frame #: 14
+(0,0):
+<thing> Fred
+frame #: 15
+(0,0):
+<thing> Fred
+frame #: 16
+(0,0):
+<thing> Fred
+frame #: 17
+(0,0):
+<thing> Fred
+frame #: 18
+(0,0):
+<thing> Fred
+frame #: 19
+(0,0):
+<thing> Fred
+frame #: 20
+(0,0):
+<thing> Fred
+frame #: 21
+(0,0):
+<thing> Fred
+frame #: 22
+(0,0):
+<thing> Fred
+frame #: 23
+(0,0):
+<thing> Fred
+frame #: 24
+(0,0):
+<thing> Fred
+frame #: 25
+(0,0):
+<thing> Fred
+frame #: 26
+(0,0):
+<thing> Fred
+frame #: 27
+(0,0):
+<thing> Fred
+frame #: 28
+(0,0):
+<thing> Fred
+frame #: 29
+(0,0):
+<thing> Fred
+frame #: 30
+(0,0):
+<thing> Fred
+frame #: 31
+(0,0):
+<thing> Fred
+frame #: 32
+(0,0):
+<thing> Fred
+frame #: 33
+(0,0):
+<thing> Fred
+frame #: 34
+(0,0):
+<thing> Fred
+frame #: 35
+(0,0):
+<thing> Fred
+frame #: 36
+(0,0):
+<thing> Fred
+frame #: 37
+(0,0):
+<thing> Fred
+frame #: 38
+(0,0):
+<thing> Fred
+frame #: 39
+(0,0):
+<thing> Fred
+frame #: 40
+(0,0):
+<thing> Fred
+frame #: 41
+(0,0):
+<thing> Fred
+frame #: 42
+(0,0):
+<thing> Fred
+frame #: 43
+(0,0):
+<thing> Fred
+frame #: 44
+(0,0):
+<thing> Fred
+frame #: 45
+(0,0):
+<thing> Fred
+frame #: 46
+(0,0):
+<thing> Fred
+frame #: 47
+(0,0):
+<thing> Fred
+frame #: 48
+(0,0):
+<thing> Fred
+frame #: 49
+(0,0):
+<thing> Fred
+frame #: 50
+(0,0):
+<thing> Fred
+frame #: 51
+(0,0):
+<thing> Fred
+frame #: 52
+(0,0):
+<thing> Fred
+frame #: 53
+(0,0):
+<thing> Fred
+frame #: 54
+(0,0):
+<thing> Fred
+frame #: 55
+(0,0):
+<thing> Fred
+frame #: 56
+(0,0):
+<thing> Fred
+frame #: 57
+(0,0):
+<thing> Fred
+frame #: 58
+(0,0):
+<thing> Fred
+frame #: 59
+(0,0):
+<thing> Fred
+frame #: 60
+(0,0):
+<thing> Fred
+frame #: 61
+(0,0):
+<thing> Fred
+frame #: 62
+(0,0):
+<thing> Fred
+frame #: 63
+(0,0):
+<thing> Fred
+frame #: 64
+(0,0):
+<thing> Fred
+frame #: 65
+(0,0):
+<thing> Fred
+frame #: 66
+(0,0):
+<thing> Fred
+frame #: 67
+(0,0):
+<thing> Fred
+frame #: 68
+(0,0):
+<thing> Fred
+frame #: 69
+(0,0):
+<thing> Fred
+frame #: 70
+(0,0):
+<thing> Fred
+frame #: 71
+(0,0):
+<thing> Fred
+frame #: 72
+(0,0):
+<thing> Fred
+frame #: 73
+(0,0):
+<thing> Fred
+frame #: 74
+(0,0):
+<thing> Fred
+frame #: 75
+(0,0):
+<thing> Fred
+frame #: 76
+(0,0):
+<thing> Fred
+frame #: 77
+(0,0):
+<thing> Fred
+frame #: 78
+(0,0):
+<thing> Fred
+frame #: 79
+(0,0):
+<thing> Fred
+frame #: 80
+(0,0):
+<thing> Fred
+frame #: 81
+(0,0):
+<thing> Fred
+frame #: 82
+(0,0):
+<thing> Fred
+frame #: 83
+(0,0):
+<thing> Fred
+frame #: 84
+(0,0):
+<thing> Fred
+frame #: 85
+(0,0):
+<thing> Fred
+frame #: 86
+(0,0):
+<thing> Fred
+frame #: 87
+(0,0):
+<thing> Fred
+frame #: 88
+(0,0):
+<thing> Fred
+frame #: 89
+(0,0):
+<thing> Fred
+frame #: 90
+(0,0):
+<thing> Fred
+frame #: 91
+(0,0):
+<thing> Fred
+frame #: 92
+(0,0):
+<thing> Fred
+frame #: 93
+(0,0):
+<thing> Fred
+frame #: 94
+(0,0):
+<thing> Fred
+frame #: 95
+(0,0):
+<thing> Fred
+frame #: 96
+(0,0):
+<thing> Fred
+frame #: 97
+(0,0):
+<thing> Fred
+frame #: 98
+(0,0):
+<thing> Fred
+frame #: 99
+(0,0):
+<thing> Fred
+frame #: 100
+(0,0):
+<thing> Fred


### PR DESCRIPTION
This branch delays the evaluation of the distance of a move until it is expanded.

For the moment, I've included a simple system_test, which will need to be further fleshed out.  So this branch is not quite ready to be merged just yet.

@ZhangWangda , I'm sharing this now primarily because I think it may be helpful when implementing WordsWait to do the same delayed evaluation.  (Similar to what you already did for WordsSay.)

Closes #85 
