### PR TITLE
Queued Property Assignment

### DIFF
--- a/src/words/ast/AST.java
+++ b/src/words/ast/AST.java
@@ -16,11 +16,22 @@ public abstract class AST {
 	 * 
 	 * @param level the indentation level
 	 */
-	abstract public void dump(int level);
+	public abstract void dump(int level);
 	
 	/**
 	 * Evaluate an AST node to return an ASTValue and possibly have side effects on the passed environment.
+	 * 
 	 * @throws WordsRuntimeException 
 	 */
 	public abstract ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException;
+
+	/**
+	 * Evaluate an AST node using inherited attributes to return an ASTValue and possibly having side effects on the passed environment.
+	 * 
+	 * Subclasses may override this method if they use inherited attributes.  If not, their implementation of eval() without
+	 * inherited attributes will be called.
+	 * 
+	 * @throws WordsRuntimeException
+	 */
+	public ASTValue eval(WordsEnvironment environment, Object inherited) throws WordsRuntimeException { return eval(environment); };
 }

--- a/src/words/ast/ASTValue.java
+++ b/src/words/ast/ASTValue.java
@@ -3,6 +3,7 @@ package words.ast;
 import words.environment.Direction;
 import words.environment.WordsObject;
 import words.environment.WordsPosition;
+import words.environment.WordsProperty;
 
 /**
  * A dynamically-typed value that an AST node can return as its result.
@@ -90,5 +91,25 @@ public class ASTValue {
 		}
 		
 		return this;
+	}
+	
+	/**
+	 * Returns a WordsProperty object of type NUM, STRING, OBJ, or NOTHING
+	 * corresponding to this ASTValue.  Calling on an ASTValue with a type
+	 * other than those listed above is prohibited.
+	 */
+	public WordsProperty toWordsProperty() {
+		switch (this.type) {
+			case NUM:
+				return new WordsProperty(this.numValue);
+			case STRING:
+				return new WordsProperty(this.stringValue);
+			case OBJ:
+				return new WordsProperty(this.objValue);
+			case NOTHING:
+				return new WordsProperty(WordsProperty.PropertyType.NOTHING);
+			default:
+				throw new AssertionError("Cannot convert ASTValue of type " + this.type.toString() + "to WordsProperty");
+		}
 	}
 }

--- a/src/words/ast/INodeAssign.java
+++ b/src/words/ast/INodeAssign.java
@@ -23,25 +23,7 @@ public class INodeAssign extends INode {
 		String propertyName = children.get(1).eval(environment).stringValue;
 		ASTValue propertyASTValue = children.get(2).eval(environment);	
 
-		WordsProperty wordsProp = null;
-		switch (propertyASTValue.type) {
-			case NUM:
-				wordsProp = new WordsProperty(propertyASTValue.numValue);
-				break;
-			case STRING:
-				wordsProp = new WordsProperty(propertyASTValue.stringValue);
-				break;
-			case OBJ:
-				wordsProp = new WordsProperty(propertyASTValue.objValue);
-				break;
-			case NOTHING:
-				wordsProp = new WordsProperty(WordsProperty.PropertyType.NOTHING);
-				break;
-			default:
-				throw new AssertionError("Shouldn't get here");
-		}
-
-		obj.setProperty(propertyName, wordsProp);
+		obj.setProperty(propertyName, propertyASTValue.toWordsProperty());
 		
 		return null;
 	}

--- a/src/words/ast/INodeQueueAssign.java
+++ b/src/words/ast/INodeQueueAssign.java
@@ -13,7 +13,7 @@ public class INodeQueueAssign extends INode {
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
 		ASTValue referenceObject = children.get(0).eval(environment);
-		INode propertyList = (INode) children.get(1);
+		AST propertyList = children.get(1);
 		ASTValue doNow = children.get(2) != null ? children.get(2).eval(environment) : null;
 		
 		WordsPropertyAssignment action = new WordsPropertyAssignment(propertyList);

--- a/src/words/ast/INodeQueueAssign.java
+++ b/src/words/ast/INodeQueueAssign.java
@@ -1,6 +1,8 @@
 package words.ast;
 
 import words.environment.WordsEnvironment;
+import words.environment.WordsObject;
+import words.environment.WordsPropertyAssignment;
 import words.exceptions.WordsRuntimeException;
 
 public class INodeQueueAssign extends INode {
@@ -10,7 +12,19 @@ public class INodeQueueAssign extends INode {
 
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
-		// TODO
-		throw new AssertionError("Not yet implemented");
+		ASTValue referenceObject = children.get(0).eval(environment);
+		INode propertyList = (INode) children.get(1);
+		ASTValue doNow = children.get(2) != null ? children.get(2).eval(environment) : null;
+		
+		WordsPropertyAssignment action = new WordsPropertyAssignment(propertyList);
+		WordsObject object = referenceObject.objValue;
+		
+		if (doNow == null) {
+			object.enqueueAction(action);
+		} else {
+			object.enqueueActionAtFront(action);
+		}
+		
+		return null;
 	}
 }

--- a/src/words/ast/INodeQueueAssignProperty.java
+++ b/src/words/ast/INodeQueueAssignProperty.java
@@ -1,6 +1,7 @@
 package words.ast;
 
 import words.environment.WordsEnvironment;
+import words.environment.WordsObject;
 import words.exceptions.WordsRuntimeException;
 
 public class INodeQueueAssignProperty extends INode {
@@ -10,6 +11,18 @@ public class INodeQueueAssignProperty extends INode {
 
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
-		throw new AssertionError("Evaluated by partent");
+		assert false : "Cannot eval INodeQueueAssignPropertyList without inherited WordsObject";
+		return null;
+	}
+	
+	@Override
+	public ASTValue eval(WordsEnvironment environment, Object inherited) throws WordsRuntimeException {
+		WordsObject object = (WordsObject) inherited;
+		
+		String propertyName = children.get(0).eval(environment).stringValue;
+		ASTValue propertyASTValue = children.get(1).eval(environment);
+		object.setProperty(propertyName, propertyASTValue.toWordsProperty());
+		
+		return null;
 	}
 }

--- a/src/words/ast/INodeQueueAssignProperty.java
+++ b/src/words/ast/INodeQueueAssignProperty.java
@@ -10,7 +10,6 @@ public class INodeQueueAssignProperty extends INode {
 
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
-		// TODO
-		throw new AssertionError("Not yet implemented");
+		throw new AssertionError("Evaluated by partent");
 	}
 }

--- a/src/words/ast/INodeQueueAssignPropertyList.java
+++ b/src/words/ast/INodeQueueAssignPropertyList.java
@@ -10,6 +10,16 @@ public class INodeQueueAssignPropertyList extends INode {
 
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
-		throw new AssertionError("Evaluated by parent");
+		assert false : "Cannot eval INodeQueueAssignPropertyList without inherited WordsObject";
+		return null;
+	}
+	
+	@Override
+	public ASTValue eval(WordsEnvironment environment, Object inherited) throws WordsRuntimeException {
+		for (AST ast : children) {
+			ast.eval(environment, inherited);
+		}
+		
+		return null;
 	}
 }

--- a/src/words/ast/INodeQueueAssignPropertyList.java
+++ b/src/words/ast/INodeQueueAssignPropertyList.java
@@ -10,7 +10,6 @@ public class INodeQueueAssignPropertyList extends INode {
 
 	@Override
 	public ASTValue eval(WordsEnvironment environment) throws WordsRuntimeException {
-		// TODO
-		throw new AssertionError("Not yet implemented");
+		throw new AssertionError("Evaluated by parent");
 	}
 }

--- a/src/words/ast/INodeQueueMove.java
+++ b/src/words/ast/INodeQueueMove.java
@@ -1,6 +1,5 @@
 package words.ast;
 
-import words.ast.ASTValue.ValueType;
 import words.environment.*;
 import words.exceptions.*;
 
@@ -14,7 +13,7 @@ public class INodeQueueMove extends INode {
 		ASTValue referenceObject = children.get(0).eval(environment);
 		ASTValue identifier = children.get(1).eval(environment);
 		ASTValue direction = children.get(2).eval(environment);
-		ASTValue distance = children.get(3) != null ? children.get(3).eval(environment) : new ASTValue(1);
+		AST distance = children.get(3);
 		ASTValue doNow = children.get(4) != null ? children.get(4).eval(environment) : null;
 		
 		WordsObject object;
@@ -33,8 +32,7 @@ public class INodeQueueMove extends INode {
 		
 		assert(direction.type == ASTValue.ValueType.DIRECTION) : "Expected direction";
 		
-		//TODO: Distance = 0 should create a wait method
-		WordsMove action = new WordsMove(direction.directionValue, distance.numValue);
+		WordsMove action = new WordsMove(direction.directionValue, distance);
 		
 		if (doNow == null) {
 			object.enqueueAction(action);

--- a/src/words/environment/WordsPropertyAssignment.java
+++ b/src/words/environment/WordsPropertyAssignment.java
@@ -2,10 +2,17 @@ package words.environment;
 import java.util.LinkedList;
 
 import words.ast.AST;
+import words.ast.ASTValue;
+import words.ast.INode;
+import words.exceptions.WordsProgramException;
+import words.exceptions.WordsRuntimeException;
 
 public class WordsPropertyAssignment extends WordsAction {
-	private String propertyName;
-	private AST propertyValue;
+	private INode propertyAssignmentList;
+	
+	public WordsPropertyAssignment(INode propertyAssignmentList) {
+		this.propertyAssignmentList = propertyAssignmentList;
+	}
 	
 	@Override
 	public boolean isExecutable() {
@@ -13,12 +20,44 @@ public class WordsPropertyAssignment extends WordsAction {
 	}
 
 	@Override
-	protected void doExecute(WordsObject object, WordsEnvironment environment) {
-		// TODO
-		
-		/*
-		 * Evaluate propertyValue, check result if needed, and assign it to propertyName using the object's methods for that
-		 */
+	protected void doExecute(WordsObject object, WordsEnvironment environment) throws WordsProgramException {
+		for (AST p : propertyAssignmentList.children) {
+			INode propertyAssign = (INode) p;
+
+			String propertyName = null;
+			ASTValue propertyASTValue = null;
+			
+			try {
+				propertyName = propertyAssign.children.get(0).eval(environment).stringValue;
+				propertyASTValue = propertyAssign.children.get(1).eval(environment);
+			} catch (WordsRuntimeException e) {
+				throw new WordsProgramException(propertyAssign, e);
+			}
+			
+			WordsProperty wordsProp = null;
+			switch (propertyASTValue.type) {
+				case NUM:
+					wordsProp = new WordsProperty(propertyASTValue.numValue);
+					break;
+				case STRING:
+					wordsProp = new WordsProperty(propertyASTValue.stringValue);
+					break;
+				case OBJ:
+					wordsProp = new WordsProperty(propertyASTValue.objValue);
+					break;
+				case NOTHING:
+					wordsProp = new WordsProperty(WordsProperty.PropertyType.NOTHING);
+					break;
+				default:
+					throw new AssertionError("Shouldn't get here");
+			}
+
+			try {
+				object.setProperty(propertyName, wordsProp);
+			} catch (WordsRuntimeException e) {
+				throw new WordsProgramException(propertyAssign, e);
+			}
+		}
 	}
 
 	@Override

--- a/src/words/environment/WordsPropertyAssignment.java
+++ b/src/words/environment/WordsPropertyAssignment.java
@@ -24,36 +24,10 @@ public class WordsPropertyAssignment extends WordsAction {
 		for (AST p : propertyAssignmentList.children) {
 			INode propertyAssign = (INode) p;
 
-			String propertyName = null;
-			ASTValue propertyASTValue = null;
-			
 			try {
-				propertyName = propertyAssign.children.get(0).eval(environment).stringValue;
-				propertyASTValue = propertyAssign.children.get(1).eval(environment);
-			} catch (WordsRuntimeException e) {
-				throw new WordsProgramException(propertyAssign, e);
-			}
-			
-			WordsProperty wordsProp = null;
-			switch (propertyASTValue.type) {
-				case NUM:
-					wordsProp = new WordsProperty(propertyASTValue.numValue);
-					break;
-				case STRING:
-					wordsProp = new WordsProperty(propertyASTValue.stringValue);
-					break;
-				case OBJ:
-					wordsProp = new WordsProperty(propertyASTValue.objValue);
-					break;
-				case NOTHING:
-					wordsProp = new WordsProperty(WordsProperty.PropertyType.NOTHING);
-					break;
-				default:
-					throw new AssertionError("Shouldn't get here");
-			}
-
-			try {
-				object.setProperty(propertyName, wordsProp);
+				String propertyName = propertyAssign.children.get(0).eval(environment).stringValue;
+				ASTValue propertyASTValue = propertyAssign.children.get(1).eval(environment);
+				object.setProperty(propertyName, propertyASTValue.toWordsProperty());
 			} catch (WordsRuntimeException e) {
 				throw new WordsProgramException(propertyAssign, e);
 			}

--- a/src/words/environment/WordsPropertyAssignment.java
+++ b/src/words/environment/WordsPropertyAssignment.java
@@ -2,15 +2,13 @@ package words.environment;
 import java.util.LinkedList;
 
 import words.ast.AST;
-import words.ast.ASTValue;
-import words.ast.INode;
 import words.exceptions.WordsProgramException;
 import words.exceptions.WordsRuntimeException;
 
 public class WordsPropertyAssignment extends WordsAction {
-	private INode propertyAssignmentList;
+	private AST propertyAssignmentList;
 	
-	public WordsPropertyAssignment(INode propertyAssignmentList) {
+	public WordsPropertyAssignment(AST propertyAssignmentList) {
 		this.propertyAssignmentList = propertyAssignmentList;
 	}
 	
@@ -21,16 +19,10 @@ public class WordsPropertyAssignment extends WordsAction {
 
 	@Override
 	protected void doExecute(WordsObject object, WordsEnvironment environment) throws WordsProgramException {
-		for (AST p : propertyAssignmentList.children) {
-			INode propertyAssign = (INode) p;
-
-			try {
-				String propertyName = propertyAssign.children.get(0).eval(environment).stringValue;
-				ASTValue propertyASTValue = propertyAssign.children.get(1).eval(environment);
-				object.setProperty(propertyName, propertyASTValue.toWordsProperty());
-			} catch (WordsRuntimeException e) {
-				throw new WordsProgramException(propertyAssign, e);
-			}
+		try {
+			propertyAssignmentList.eval(environment, object);
+		} catch (WordsRuntimeException e) {
+			throw new WordsProgramException(propertyAssignmentList, e);
 		}
 	}
 

--- a/system_test/DelayEvalTest.words
+++ b/system_test/DelayEvalTest.words
@@ -1,0 +1,8 @@
+Fred is a thing at 0,0.
+Fred's dist is 4-3.
+
+Make Fred move left Fred's dist.
+
+Fred's dist is 1+2.
+
+Make Fred move right Fred's dist.

--- a/system_test/DelayEvalTest.words
+++ b/system_test/DelayEvalTest.words
@@ -1,8 +1,8 @@
 Fred is a thing at 0,0.
-Fred's dist is 4-3.
 
-Make Fred move left Fred's dist.
+Fred's dist is 4-3.
+Make Fred move left Fred's dist.	// Should move left 3, since by time of dequeue, Fred's dist is 3 as set below
 
 Fred's dist is 1+2.
-
 Make Fred move right Fred's dist.
+Make Fred say Fred's dist.

--- a/system_test/DelayEvalTest.words.log
+++ b/system_test/DelayEvalTest.words.log
@@ -1,0 +1,300 @@
+frame #: 1
+(0,0):
+<thing> Fred
+frame #: 2
+(-1,0):
+<thing> Fred
+frame #: 3
+(-2,0):
+<thing> Fred
+frame #: 4
+(-3,0):
+<thing> Fred
+frame #: 5
+(-2,0):
+<thing> Fred
+frame #: 6
+(-1,0):
+<thing> Fred
+frame #: 7
+(0,0):
+<thing> Fred
+frame #: 8
+(0,0):
+<thing> Fred
+frame #: 9
+(0,0):
+<thing> Fred
+frame #: 10
+(0,0):
+<thing> Fred
+frame #: 11
+(0,0):
+<thing> Fred
+frame #: 12
+(0,0):
+<thing> Fred
+frame #: 13
+(0,0):
+<thing> Fred
+frame #: 14
+(0,0):
+<thing> Fred
+frame #: 15
+(0,0):
+<thing> Fred
+frame #: 16
+(0,0):
+<thing> Fred
+frame #: 17
+(0,0):
+<thing> Fred
+frame #: 18
+(0,0):
+<thing> Fred
+frame #: 19
+(0,0):
+<thing> Fred
+frame #: 20
+(0,0):
+<thing> Fred
+frame #: 21
+(0,0):
+<thing> Fred
+frame #: 22
+(0,0):
+<thing> Fred
+frame #: 23
+(0,0):
+<thing> Fred
+frame #: 24
+(0,0):
+<thing> Fred
+frame #: 25
+(0,0):
+<thing> Fred
+frame #: 26
+(0,0):
+<thing> Fred
+frame #: 27
+(0,0):
+<thing> Fred
+frame #: 28
+(0,0):
+<thing> Fred
+frame #: 29
+(0,0):
+<thing> Fred
+frame #: 30
+(0,0):
+<thing> Fred
+frame #: 31
+(0,0):
+<thing> Fred
+frame #: 32
+(0,0):
+<thing> Fred
+frame #: 33
+(0,0):
+<thing> Fred
+frame #: 34
+(0,0):
+<thing> Fred
+frame #: 35
+(0,0):
+<thing> Fred
+frame #: 36
+(0,0):
+<thing> Fred
+frame #: 37
+(0,0):
+<thing> Fred
+frame #: 38
+(0,0):
+<thing> Fred
+frame #: 39
+(0,0):
+<thing> Fred
+frame #: 40
+(0,0):
+<thing> Fred
+frame #: 41
+(0,0):
+<thing> Fred
+frame #: 42
+(0,0):
+<thing> Fred
+frame #: 43
+(0,0):
+<thing> Fred
+frame #: 44
+(0,0):
+<thing> Fred
+frame #: 45
+(0,0):
+<thing> Fred
+frame #: 46
+(0,0):
+<thing> Fred
+frame #: 47
+(0,0):
+<thing> Fred
+frame #: 48
+(0,0):
+<thing> Fred
+frame #: 49
+(0,0):
+<thing> Fred
+frame #: 50
+(0,0):
+<thing> Fred
+frame #: 51
+(0,0):
+<thing> Fred
+frame #: 52
+(0,0):
+<thing> Fred
+frame #: 53
+(0,0):
+<thing> Fred
+frame #: 54
+(0,0):
+<thing> Fred
+frame #: 55
+(0,0):
+<thing> Fred
+frame #: 56
+(0,0):
+<thing> Fred
+frame #: 57
+(0,0):
+<thing> Fred
+frame #: 58
+(0,0):
+<thing> Fred
+frame #: 59
+(0,0):
+<thing> Fred
+frame #: 60
+(0,0):
+<thing> Fred
+frame #: 61
+(0,0):
+<thing> Fred
+frame #: 62
+(0,0):
+<thing> Fred
+frame #: 63
+(0,0):
+<thing> Fred
+frame #: 64
+(0,0):
+<thing> Fred
+frame #: 65
+(0,0):
+<thing> Fred
+frame #: 66
+(0,0):
+<thing> Fred
+frame #: 67
+(0,0):
+<thing> Fred
+frame #: 68
+(0,0):
+<thing> Fred
+frame #: 69
+(0,0):
+<thing> Fred
+frame #: 70
+(0,0):
+<thing> Fred
+frame #: 71
+(0,0):
+<thing> Fred
+frame #: 72
+(0,0):
+<thing> Fred
+frame #: 73
+(0,0):
+<thing> Fred
+frame #: 74
+(0,0):
+<thing> Fred
+frame #: 75
+(0,0):
+<thing> Fred
+frame #: 76
+(0,0):
+<thing> Fred
+frame #: 77
+(0,0):
+<thing> Fred
+frame #: 78
+(0,0):
+<thing> Fred
+frame #: 79
+(0,0):
+<thing> Fred
+frame #: 80
+(0,0):
+<thing> Fred
+frame #: 81
+(0,0):
+<thing> Fred
+frame #: 82
+(0,0):
+<thing> Fred
+frame #: 83
+(0,0):
+<thing> Fred
+frame #: 84
+(0,0):
+<thing> Fred
+frame #: 85
+(0,0):
+<thing> Fred
+frame #: 86
+(0,0):
+<thing> Fred
+frame #: 87
+(0,0):
+<thing> Fred
+frame #: 88
+(0,0):
+<thing> Fred
+frame #: 89
+(0,0):
+<thing> Fred
+frame #: 90
+(0,0):
+<thing> Fred
+frame #: 91
+(0,0):
+<thing> Fred
+frame #: 92
+(0,0):
+<thing> Fred
+frame #: 93
+(0,0):
+<thing> Fred
+frame #: 94
+(0,0):
+<thing> Fred
+frame #: 95
+(0,0):
+<thing> Fred
+frame #: 96
+(0,0):
+<thing> Fred
+frame #: 97
+(0,0):
+<thing> Fred
+frame #: 98
+(0,0):
+<thing> Fred
+frame #: 99
+(0,0):
+<thing> Fred
+frame #: 100
+(0,0):
+<thing> Fred

--- a/system_test/DelayEvalTest.words.log
+++ b/system_test/DelayEvalTest.words.log
@@ -21,280 +21,280 @@ frame #: 7
 <thing> Fred
 frame #: 8
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 9
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 10
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 11
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 12
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 13
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 14
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 15
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 16
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 17
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 18
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 19
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 20
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 21
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 22
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 23
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 24
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 25
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 26
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 27
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 28
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 29
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 30
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 31
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 32
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 33
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 34
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 35
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 36
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 37
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 38
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 39
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 40
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 41
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 42
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 43
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 44
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 45
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 46
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 47
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 48
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 49
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 50
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 51
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 52
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 53
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 54
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 55
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 56
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 57
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 58
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 59
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 60
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 61
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 62
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 63
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 64
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 65
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 66
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 67
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 68
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 69
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 70
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 71
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 72
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 73
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 74
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 75
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 76
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 77
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 78
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 79
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 80
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 81
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 82
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 83
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 84
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 85
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 86
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 87
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 88
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 89
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 90
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 91
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 92
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 93
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 94
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 95
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 96
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 97
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 98
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 99
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"
 frame #: 100
 (0,0):
-<thing> Fred
+<thing> Fred "3.000000"

--- a/system_test/QueuePropertiesTest.words
+++ b/system_test/QueuePropertiesTest.words
@@ -1,0 +1,18 @@
+Fred is a thing at 0,0.
+
+Make Fred's property be 1.
+Make Fred say Fred's property.
+
+Make Fred's height be 68, weight be 150, gender be "male".
+Make Fred say Fred's height.
+Make Fred say Fred's weight.
+Make Fred say Fred's gender.
+
+Make Fred's row be 2, column be 4.
+Make Fred say "I jumped".
+
+Bob is a thing at -2, -2.
+Bob's friend is Fred.
+
+Make Bob's friend's property be 2.
+Make Fred say Fred's property.

--- a/system_test/QueuePropertiesTest.words.log
+++ b/system_test/QueuePropertiesTest.words.log
@@ -1,0 +1,500 @@
+frame #: 1
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred
+frame #: 2
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred
+frame #: 3
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred "1.000000"
+frame #: 4
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred "1.000000"
+frame #: 5
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred "68.000000"
+frame #: 6
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred "150.000000"
+frame #: 7
+(-2,-2):
+<thing> Bob
+(0,0):
+<thing> Fred "male"
+frame #: 8
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "male"
+frame #: 9
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "I jumped"
+frame #: 10
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "I jumped"
+frame #: 11
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 12
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 13
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 14
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 15
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 16
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 17
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 18
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 19
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 20
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 21
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 22
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 23
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 24
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 25
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 26
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 27
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 28
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 29
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 30
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 31
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 32
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 33
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 34
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 35
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 36
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 37
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 38
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 39
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 40
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 41
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 42
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 43
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 44
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 45
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 46
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 47
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 48
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 49
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 50
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 51
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 52
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 53
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 54
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 55
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 56
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 57
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 58
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 59
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 60
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 61
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 62
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 63
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 64
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 65
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 66
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 67
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 68
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 69
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 70
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 71
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 72
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 73
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 74
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 75
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 76
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 77
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 78
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 79
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 80
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 81
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 82
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 83
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 84
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 85
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 86
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 87
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 88
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 89
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 90
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 91
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 92
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 93
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 94
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 95
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 96
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 97
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 98
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 99
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"
+frame #: 100
+(-2,-2):
+<thing> Bob
+(4,2):
+<thing> Fred "2.000000"

--- a/test/words/test/TestINodeQueueAssign.java
+++ b/test/words/test/TestINodeQueueAssign.java
@@ -1,0 +1,90 @@
+package words.test;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import words.ast.*;
+import words.environment.*;
+import words.exceptions.*;
+
+public class TestINodeQueueAssign extends TestINode {
+	String prop1Name = "prop1";
+	String prop2Name = "prop2";
+	String prop3Name = "prop3";
+	
+	String prop1Value = "prop1Value";
+	String prop2Value = "prop2Value";
+	String prop3Value = "prop3Value";	
+	
+	INodeQueueAssignProperty prop1 = new INodeQueueAssignProperty(new LNodeString(prop1Name), new LNodeString(prop1Value));
+	INodeQueueAssignProperty prop2 = new INodeQueueAssignProperty(new LNodeString(prop2Name), new LNodeString(prop2Value));
+	INodeQueueAssignProperty prop3 = new INodeQueueAssignProperty(new LNodeString(prop3Name), new LNodeString(prop3Value));
+	
+	INodeQueueAssignPropertyList onePropList = new INodeQueueAssignPropertyList(prop1);
+	INodeQueueAssignPropertyList threePropList = new INodeQueueAssignPropertyList(prop1, prop2, prop3);
+	
+	INodeReferenceList refList = new INodeReferenceList(new LNodeReference("Fred's"));
+	
+	@Test
+	public void queueAssignShouldWorkForOneProperty() throws WordsRuntimeException {
+		environment.createObject("Fred", "thing", new WordsPosition(0,0));
+		loop.fastForwardEnvironment(1); //object is created with a 1 frame wait, so use it up.
+
+		assertEquals("Property does not currently exist", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);
+		
+		INodeQueueAssign testNode = new INodeQueueAssign(refList, onePropList, null);
+		loop.enqueueAST(testNode);
+		assertEquals("Property does not exist after enqueueing", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);		
+		
+		loop.fastForwardEnvironment(1);
+		assertEquals("Property exists after executing", environment.getObject("Fred").getProperty(prop1Name).stringProperty, prop1Value);
+	}
+	
+	@Test
+	public void queueAssignShouldSimultaneouslyAssignMultipleProperties() throws WordsRuntimeException {
+		environment.createObject("Fred", "thing", new WordsPosition(0,0));
+		loop.fastForwardEnvironment(1); //object is created with a 1 frame wait, so use it up.
+		assertEquals("Property 1 does not currently exist", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 2 does not currently exist", environment.getObject("Fred").getProperty(prop2Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 3 does not currently exist", environment.getObject("Fred").getProperty(prop3Name).type, WordsProperty.PropertyType.NOTHING);
+		
+		INodeQueueAssign testNode = new INodeQueueAssign(refList, threePropList, null);
+		loop.enqueueAST(testNode);
+		assertEquals("Property 1 does not exist after enqueueing", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 2 does not exist after enqueueing", environment.getObject("Fred").getProperty(prop2Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 3 does not exist after enqueueing", environment.getObject("Fred").getProperty(prop3Name).type, WordsProperty.PropertyType.NOTHING);
+		
+		loop.fastForwardEnvironment(1);
+		assertEquals("Property 1 exists after executing", environment.getObject("Fred").getProperty(prop1Name).stringProperty, prop1Value);
+		assertEquals("Property 2 exists after executing", environment.getObject("Fred").getProperty(prop2Name).stringProperty, prop2Value);
+		assertEquals("Property 3 exists after executing", environment.getObject("Fred").getProperty(prop3Name).stringProperty, prop3Value);
+	}
+	
+	@Test
+	public void testQueueAssignWithNow() throws WordsRuntimeException {
+		environment.createObject("Fred", "thing", new WordsPosition(0,0));
+		loop.fastForwardEnvironment(1); //object is created with a 1 frame wait, so use it up.
+		assertEquals("Property 1 does not currently exist", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 2 does not currently exist", environment.getObject("Fred").getProperty(prop2Name).type, WordsProperty.PropertyType.NOTHING);
+		
+		INodeQueueAssignPropertyList propList1 = new INodeQueueAssignPropertyList(new INodeQueueAssignProperty(new LNodeString(prop1Name), new LNodeString(prop1Value)));
+		INodeQueueAssignPropertyList propList2 = new INodeQueueAssignPropertyList(new INodeQueueAssignProperty(new LNodeString(prop2Name), new LNodeString(prop2Value)));
+		
+		INodeQueueAssign testNode1 = new INodeQueueAssign(refList, propList1, null);
+		INodeQueueAssign testNode2 = new INodeQueueAssign(refList, propList2, new LNodeNow());
+		
+		loop.enqueueAST(testNode1);
+		loop.enqueueAST(testNode2);
+		
+		assertEquals("Property 1 does not exist after enqueueing", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 2 does not exist after enqueueing", environment.getObject("Fred").getProperty(prop2Name).type, WordsProperty.PropertyType.NOTHING);
+		
+		loop.fastForwardEnvironment(1);
+		assertEquals("Property 1 does not exist after one frame", environment.getObject("Fred").getProperty(prop1Name).type, WordsProperty.PropertyType.NOTHING);
+		assertEquals("Property 2 exists after one frame", environment.getObject("Fred").getProperty(prop2Name).stringProperty, prop2Value);
+		
+		loop.fastForwardEnvironment(1);
+		assertEquals("Property 1 exists after two frames", environment.getObject("Fred").getProperty(prop1Name).stringProperty, prop1Value);
+		assertEquals("Property 2 exists after two frames", environment.getObject("Fred").getProperty(prop2Name).stringProperty, prop2Value);
+	}
+}

--- a/test/words/test/TestWordsMove.java
+++ b/test/words/test/TestWordsMove.java
@@ -1,0 +1,27 @@
+package words.test;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import words.ast.*;
+import words.environment.*;
+import words.exceptions.*;
+
+public class TestWordsMove extends TestINode {
+    @Test
+    public void testWorkingWordsMove() throws WordsRuntimeException, WordsProgramException {
+        environment.createObject("Fred", "thing", new WordsPosition(0, 0));
+        WordsAction action = new WordsMove(new Direction(Direction.Type.LEFT), twoLeaf);
+        action.expand(environment.getObject("Fred"), environment);
+    }
+
+    @Test (expected = WordsProgramException.class)
+    public void onlyOperatesOnStringsAndNumbers() throws WordsRuntimeException, WordsProgramException {
+        environment.createObject("Fred", "thing", new WordsPosition(0, 0));
+        WordsAction action1 = new WordsMove(new Direction(Direction.Type.LEFT), nothingLeaf);
+        action1.expand(environment.getObject("Fred"), environment);
+        WordsAction action2 = new WordsMove(new Direction(Direction.Type.LEFT), trueLeaf);
+        action2.expand(environment.getObject("Fred"), environment);
+    }
+
+}

--- a/test/words/test/TestWordsPropertyAssignment.java
+++ b/test/words/test/TestWordsPropertyAssignment.java
@@ -1,0 +1,17 @@
+package words.test;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import words.ast.*;
+import words.environment.*;
+import words.exceptions.*;
+
+public class TestWordsPropertyAssignment extends TestINode {
+    @Test
+    public void testWorkingWordsPropertyAssignment() throws WordsRuntimeException, WordsProgramException {
+        environment.createObject("Fred", "thing", new WordsPosition(0, 0));
+        WordsAction action = new WordsPropertyAssignment(new INodeQueueAssignPropertyList(new INodeQueueAssignProperty(stringLeaf, numLeaf)));
+        action.execute(environment.getObject("Fred"), environment);
+    }
+}


### PR DESCRIPTION
This branch has an implementation of queued property assignment (statements like "Make Fred's height be 68, weight be 150, age be 30.").  It also includes an implementation for inherited attributes in our AST (discussed more below).  Up to know, we've only needed synthesized attributes (INodeAdd returns a sum, etc.), but here is a case where I believe the proper implementation is with an inherited attribute.  I think inherited attributes will also be useful for class definition statements.

Closes #70 
Closes #85 

To understand the implementation of queued property assignment, the grammar defines three INodes:
- INodeQueueAssign: Corresponds to the entire example statement above
- INodeQueueAssignPropertyList: Corresponds to "height be 68, weight be 150, age be 30" above
- INodeQueueAssignProperty: Corresponds to "height be 68" or the other two above

Now, consider INodeQueueAssignProperty's implementation of eval().  It needs to know what object to set the property on.  But obviously, it doesn't know that from its children (its children are just the property name and property value expression).  The object to set the property on is known only to the grandparent node.  Thus, INodeQueueAssignProperty must inherit that WordsObject from the grandparent.

To implement that, I added a second eval() method to the abstract INode class which takes an Object (in the Java sense) parameter called inherited.  The default is just to ignore any passed inherited attribute and call the regular eval() implementation.  However, INode subclasses can override the default if they want to use the inherited attribute.  In their implementation, they cast the Java Object into whatever they know it was that their caller passed in (which could be a HashMap if they needed to inherit multiple properties, though I doubt we'll need that).

You can see this in action in the doExecute() method of WordsPropertyAssignment.  Here, I call the propertyAssignmentList's eval() method, passing the WordsObject as the inherited attribute.

Separately, I noticed that INodeQueueMove and WordsMove was evaluating the distance expression immediately instead of when the WordsMove action is expanded.  I fixed that on a separate branch merged into this one and showing as a single pull request.

Two other minor things to note about this branch:
- There is now more than one place where we need to take an ASTValue of NUM, STRING, OBJ, or NOTHING type and convert it to a corresponding WordsProperty.  So I factored that out and made it a method of ASTValue.
- I added some additional tests for INodeWordsMove
