### PR TITLE
Refactor Direction Class

### DIFF
--- a/src/words/Words.y
+++ b/src/words/Words.y
@@ -302,11 +302,11 @@ queue_assign_property:
 	;
 
 direction:
-		ANYWHERE									{ $$ = new LNodeDirection(Direction.Type.ANYWHERE); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	DOWN										{ $$ = new LNodeDirection(Direction.Type.DOWN); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	LEFT										{ $$ = new LNodeDirection(Direction.Type.LEFT); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	RIGHT										{ $$ = new LNodeDirection(Direction.Type.RIGHT); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	UP											{ $$ = new LNodeDirection(Direction.Type.UP); ((AST) $$).lineNumber = lexer.lineNumber; }
+		ANYWHERE									{ $$ = new LNodeDirection(Direction.ANYWHERE); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	DOWN										{ $$ = new LNodeDirection(Direction.DOWN); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	LEFT										{ $$ = new LNodeDirection(Direction.LEFT); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	RIGHT										{ $$ = new LNodeDirection(Direction.RIGHT); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	UP											{ $$ = new LNodeDirection(Direction.UP); ((AST) $$).lineNumber = lexer.lineNumber; }
 	;
 
 now:

--- a/src/words/ast/ASTValue.java
+++ b/src/words/ast/ASTValue.java
@@ -22,7 +22,7 @@ public class ASTValue {
 	public double numValue;
 	public String stringValue;
 	public WordsObject objValue;
-	public Direction.Type directionValue;
+	public Direction directionValue;
 	public Position positionValue;
 	
 	public ASTValue(boolean b) {
@@ -45,7 +45,7 @@ public class ASTValue {
 		this.objValue = obj;
 	}
 	
-	public ASTValue(Direction.Type d) {
+	public ASTValue(Direction d) {
 		this.type = Type.DIRECTION;
 		this.directionValue = d;
 	}

--- a/src/words/ast/ASTValue.java
+++ b/src/words/ast/ASTValue.java
@@ -22,7 +22,7 @@ public class ASTValue {
 	public double numValue;
 	public String stringValue;
 	public WordsObject objValue;
-	public Direction directionValue;
+	public Direction.Type directionValue;
 	public Position positionValue;
 	
 	public ASTValue(boolean b) {
@@ -45,7 +45,7 @@ public class ASTValue {
 		this.objValue = obj;
 	}
 	
-	public ASTValue(Direction d) {
+	public ASTValue(Direction.Type d) {
 		this.type = Type.DIRECTION;
 		this.directionValue = d;
 	}

--- a/src/words/ast/INodeMovesPredicate.java
+++ b/src/words/ast/INodeMovesPredicate.java
@@ -31,7 +31,7 @@ public class INodeMovesPredicate extends INodeBasicActionPredicate {
 			Action lastAction = object.getLastAction();
 			if (lastAction instanceof MoveAction) {
 				MoveAction lastMove = (MoveAction) lastAction;
-				if (moveDirection == null || moveDirection.directionValue.type == Direction.Type.ANYWHERE 
+				if (moveDirection == null || moveDirection.directionValue == Direction.Type.ANYWHERE 
 						|| moveDirection.directionValue.equals(lastMove.getDirection())) {
 					returnVal.booleanValue = true;
 					environment.enterNewLocalScope();

--- a/src/words/ast/INodeMovesPredicate.java
+++ b/src/words/ast/INodeMovesPredicate.java
@@ -31,7 +31,7 @@ public class INodeMovesPredicate extends INodeBasicActionPredicate {
 			Action lastAction = object.getLastAction();
 			if (lastAction instanceof MoveAction) {
 				MoveAction lastMove = (MoveAction) lastAction;
-				if (moveDirection == null || moveDirection.directionValue == Direction.Type.ANYWHERE 
+				if (moveDirection == null || moveDirection.directionValue == Direction.ANYWHERE 
 						|| moveDirection.directionValue.equals(lastMove.getDirection())) {
 					returnVal.booleanValue = true;
 					environment.enterNewLocalScope();

--- a/src/words/ast/LNodeDirection.java
+++ b/src/words/ast/LNodeDirection.java
@@ -6,11 +6,11 @@ import words.environment.*;
  * A syntax tree leaf node for a direction.
  */
 public class LNodeDirection extends LNode {
-	public Direction direction;
+	public Direction.Type direction;
 	
 	public LNodeDirection(Direction.Type d) {
 		super();
-		this.direction = new Direction(d);
+		this.direction = d;
 	}
 	
 	@Override

--- a/src/words/ast/LNodeDirection.java
+++ b/src/words/ast/LNodeDirection.java
@@ -6,9 +6,9 @@ import words.environment.*;
  * A syntax tree leaf node for a direction.
  */
 public class LNodeDirection extends LNode {
-	public Direction.Type direction;
+	public Direction direction;
 	
-	public LNodeDirection(Direction.Type d) {
+	public LNodeDirection(Direction d) {
 		super();
 		this.direction = d;
 	}

--- a/src/words/environment/Direction.java
+++ b/src/words/environment/Direction.java
@@ -5,24 +5,19 @@ import java.util.Random;
 /**
  * An orthogonal direction.
  */
-public class Direction {
-	/**
-	 * One of the four orthogonal directions or an indication that any direction is permitted.
-	 */
-	public static enum Type {
+public enum Direction {
 		ANYWHERE,
 		DOWN,
 		LEFT,
 		RIGHT,
-		UP
-	}
+		UP;
 	
-	public static Type[] explicit = {Type.DOWN, Type.LEFT, Type.RIGHT, Type.UP};
+	public static Direction[] explicit = {DOWN, LEFT, RIGHT, UP};
 
 	/**
 	 * Returns a random explicit direction, i.e., not ANYWHERE.
 	 */
-	public static Type getRandom() {
+	public static Direction getRandom() {
 		Random randomGenerator = new Random();
 		int randomInt = randomGenerator.nextInt(explicit.length);
 		return Direction.explicit[randomInt];		
@@ -31,16 +26,16 @@ public class Direction {
 	/**
 	 * Returns the opposite of a given direction.  Returns null if called with ANYWHERE.
 	 */
-	public static Type getOpposite(Type input) {
+	public static Direction getOpposite(Direction input) {
 		switch(input) {
 			case DOWN:
-				return Type.UP;
+				return Direction.UP;
 			case LEFT:
-				return Type.RIGHT;
+				return Direction.RIGHT;
 			case RIGHT:
-				return Type.LEFT;
+				return Direction.LEFT;
 			case UP:
-				return Type.DOWN;
+				return Direction.DOWN;
 			default:
 				break;
 		} 

--- a/src/words/environment/Direction.java
+++ b/src/words/environment/Direction.java
@@ -1,13 +1,15 @@
 package words.environment;
 
+import java.util.Random;
+
 /**
- * An orthogonal direction, possibly random.
+ * An orthogonal direction.
  */
 public class Direction {
 	/**
 	 * One of the four orthogonal directions or an indication that any direction is permitted.
 	 */
-	public enum Type {
+	public static enum Type {
 		ANYWHERE,
 		DOWN,
 		LEFT,
@@ -15,14 +17,20 @@ public class Direction {
 		UP
 	}
 	
-	public Type type;
-
 	public static Type[] explicit = {Type.DOWN, Type.LEFT, Type.RIGHT, Type.UP};
-	
-	public Direction(Type type) {
-		this.type = type;
-	}
 
+	/**
+	 * Returns a random explicit direction, i.e., not ANYWHERE.
+	 */
+	public static Type getRandom() {
+		Random randomGenerator = new Random();
+		int randomInt = randomGenerator.nextInt(explicit.length);
+		return Direction.explicit[randomInt];		
+	}
+	
+	/**
+	 * Returns the opposite of a given direction.  Returns null if called with ANYWHERE.
+	 */
 	public static Type getOpposite(Type input) {
 		switch(input) {
 			case DOWN:
@@ -33,12 +41,10 @@ public class Direction {
 				return Type.LEFT;
 			case UP:
 				return Type.DOWN;
+			default:
+				break;
 		} 
+		
 		return null;
-	}
-	
-	@Override
-	public String toString() {
-		return this.type.toString();
 	}
 }

--- a/src/words/environment/MoveAction.java
+++ b/src/words/environment/MoveAction.java
@@ -1,12 +1,11 @@
 package words.environment;
 import java.util.LinkedList;
 
-import java.util.Random;
 import words.exceptions.*;
 import words.ast.*;
 
 public class MoveAction extends Action {
-	private Direction direction;
+	private Direction.Type direction;
 	private AST distanceExpression;		// The expression whose value will be the number of moves to make; used only before the move has been expanded
 
 	/**
@@ -15,25 +14,23 @@ public class MoveAction extends Action {
 	 * 
 	 * distanceExpression may be null, in which case the WordsMove will be treated as a 1-unit move.
 	 */
-	public MoveAction(Direction direction, AST distanceExpression) {
-		if (direction.type == Direction.Type.ANYWHERE) {
-			Random randomGenerator = new Random();
-			int randomInt = randomGenerator.nextInt(4);
-			this.direction = new Direction(Direction.explicit[randomInt]);
+	public MoveAction(Direction.Type direction, AST distanceExpression) {
+		if (direction == Direction.Type.ANYWHERE) {
+			this.direction = Direction.getRandom();
 		} else {
 			this.direction = direction;
 		}
 		this.distanceExpression = distanceExpression;
 	}
 	
-	public Direction getDirection() {
+	public Direction.Type getDirection() {
 		return direction;
 	}
 
 	/**
 	 * Private constructor used to create a 1-unit move action.
 	 */
-	private MoveAction(Direction direction) {
+	private MoveAction(Direction.Type direction) {
 		this.direction = direction;
 		this.distanceExpression = null;
 	}
@@ -50,7 +47,7 @@ public class MoveAction extends Action {
 	public void doExecute(WordsObject object, Environment environment) throws WordsProgramException {
 		// We know that the distanceValue is 1
 		// ANYWHERE directions will already have been replaced to be a real direction
-		switch(direction.type) {
+		switch(direction) {
 			case DOWN:
 				object.moveDown();
 				break;
@@ -64,7 +61,7 @@ public class MoveAction extends Action {
 				object.moveUp();
 				break;
 			default:
-				throw new AssertionError("Attempted to execute direction type " + direction.type.toString());
+				throw new AssertionError("Attempted to execute direction type " + direction.toString());
 		}
 	}
 
@@ -85,7 +82,7 @@ public class MoveAction extends Action {
 
 		if (distanceValue < 0) {
 			distanceValue = -distanceValue;
-			direction.type = Direction.getOpposite(direction.type);
+			direction = Direction.getOpposite(direction);
 		}
 
 		LinkedList<Action> list = new LinkedList<Action>();

--- a/src/words/environment/MoveAction.java
+++ b/src/words/environment/MoveAction.java
@@ -5,7 +5,7 @@ import words.exceptions.*;
 import words.ast.*;
 
 public class MoveAction extends Action {
-	private Direction.Type direction;
+	private Direction direction;
 	private AST distanceExpression;		// The expression whose value will be the number of moves to make; used only before the move has been expanded
 
 	/**
@@ -14,8 +14,8 @@ public class MoveAction extends Action {
 	 * 
 	 * distanceExpression may be null, in which case the WordsMove will be treated as a 1-unit move.
 	 */
-	public MoveAction(Direction.Type direction, AST distanceExpression) {
-		if (direction == Direction.Type.ANYWHERE) {
+	public MoveAction(Direction direction, AST distanceExpression) {
+		if (direction == Direction.ANYWHERE) {
 			this.direction = Direction.getRandom();
 		} else {
 			this.direction = direction;
@@ -23,14 +23,14 @@ public class MoveAction extends Action {
 		this.distanceExpression = distanceExpression;
 	}
 	
-	public Direction.Type getDirection() {
+	public Direction getDirection() {
 		return direction;
 	}
 
 	/**
 	 * Private constructor used to create a 1-unit move action.
 	 */
-	private MoveAction(Direction.Type direction) {
+	private MoveAction(Direction direction) {
 		this.direction = direction;
 		this.distanceExpression = null;
 	}

--- a/src/words/environment/WordsObject.java
+++ b/src/words/environment/WordsObject.java
@@ -74,6 +74,8 @@ public class WordsObject {
 				cell.y = (int) Math.round(property.numProperty);
 			else
 				cell.x = (int) Math.round(property.numProperty);
+			
+			return;
 		}
 
 		if (properties.containsKey(propertyName) && property.type == Property.PropertyType.NOTHING)

--- a/test/words/test/TestINode.java
+++ b/test/words/test/TestINode.java
@@ -24,9 +24,9 @@ public class TestINode {
 	
 	AST fredStringLeaf = new LNodeString("Fred");
 	AST georgeStringLeaf = new LNodeString("George");
-	AST leftDirectionLeaf = new LNodeDirection(Direction.Type.LEFT);
-	AST rightDirectionLeaf = new LNodeDirection(Direction.Type.RIGHT);
-	AST anywhereDirectionLeaf = new LNodeDirection(Direction.Type.ANYWHERE);
+	AST leftDirectionLeaf = new LNodeDirection(Direction.LEFT);
+	AST rightDirectionLeaf = new LNodeDirection(Direction.RIGHT);
+	AST anywhereDirectionLeaf = new LNodeDirection(Direction.ANYWHERE);
 	
 	AST moveFredLeft2 = new INodeQueueMove(nothingLeaf, fredStringLeaf, leftDirectionLeaf, twoLeaf, null);
 	AST moveGeorgeLeft2 = new INodeQueueMove(nothingLeaf, georgeStringLeaf, leftDirectionLeaf, twoLeaf, null);

--- a/test/words/test/TestWordsMove.java
+++ b/test/words/test/TestWordsMove.java
@@ -9,16 +9,16 @@ public class TestWordsMove extends TestINode {
     @Test
     public void testWorkingWordsMove() throws WordsRuntimeException, WordsProgramException {
         environment.createObject("Fred", "thing", new Position(0, 0));
-        Action action = new MoveAction(new Direction(Direction.Type.LEFT), twoLeaf);
+        Action action = new MoveAction(Direction.Type.LEFT, twoLeaf);
         action.expand(environment.getObject("Fred"), environment);
     }
 
     @Test (expected = WordsProgramException.class)
     public void onlyOperatesOnStringsAndNumbers() throws WordsRuntimeException, WordsProgramException {
         environment.createObject("Fred", "thing", new Position(0, 0));
-        Action action1 = new MoveAction(new Direction(Direction.Type.LEFT), nothingLeaf);
+        Action action1 = new MoveAction(Direction.Type.LEFT, nothingLeaf);
         action1.expand(environment.getObject("Fred"), environment);
-        Action action2 = new MoveAction(new Direction(Direction.Type.LEFT), trueLeaf);
+        Action action2 = new MoveAction(Direction.Type.LEFT, trueLeaf);
         action2.expand(environment.getObject("Fred"), environment);
     }
 

--- a/test/words/test/TestWordsMove.java
+++ b/test/words/test/TestWordsMove.java
@@ -9,16 +9,16 @@ public class TestWordsMove extends TestINode {
     @Test
     public void testWorkingWordsMove() throws WordsRuntimeException, WordsProgramException {
         environment.createObject("Fred", "thing", new Position(0, 0));
-        Action action = new MoveAction(Direction.Type.LEFT, twoLeaf);
+        Action action = new MoveAction(Direction.LEFT, twoLeaf);
         action.expand(environment.getObject("Fred"), environment);
     }
 
     @Test (expected = WordsProgramException.class)
     public void onlyOperatesOnStringsAndNumbers() throws WordsRuntimeException, WordsProgramException {
         environment.createObject("Fred", "thing", new Position(0, 0));
-        Action action1 = new MoveAction(Direction.Type.LEFT, nothingLeaf);
+        Action action1 = new MoveAction(Direction.LEFT, nothingLeaf);
         action1.expand(environment.getObject("Fred"), environment);
-        Action action2 = new MoveAction(Direction.Type.LEFT, trueLeaf);
+        Action action2 = new MoveAction(Direction.LEFT, trueLeaf);
         action2.expand(environment.getObject("Fred"), environment);
     }
 

--- a/test/words/test/TestWordsObject.java
+++ b/test/words/test/TestWordsObject.java
@@ -24,10 +24,10 @@ public class TestWordsObject {
 	
 	@Test
 	public void executeNextActionShouldExecuteNextMoveAction() {
-		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.RIGHT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.RIGHT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.LEFT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.LEFT, new LNodeNum(1)));
 		
 		try {
 			obj.executeNextAction(null);
@@ -97,12 +97,12 @@ public class TestWordsObject {
 	
 	@Test
 	public void enqeueAtFrontShouldBeNextActionExecuted() {
-		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(3)));
-		obj.enqueueAction(new MoveAction(Direction.Type.UP, new LNodeNum(5)));
-		obj.enqueueAction(new MoveAction(Direction.Type.DOWN, new LNodeNum(5)));
+		obj.enqueueAction(new MoveAction(Direction.RIGHT, new LNodeNum(3)));
+		obj.enqueueAction(new MoveAction(Direction.UP, new LNodeNum(5)));
+		obj.enqueueAction(new MoveAction(Direction.DOWN, new LNodeNum(5)));
 		
 		// This should be first to be executed
-		obj.enqueueActionAtFront(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
+		obj.enqueueActionAtFront(new MoveAction(Direction.LEFT, new LNodeNum(1)));
 		
 		try {
 			obj.executeNextAction(null);

--- a/test/words/test/TestWordsObject.java
+++ b/test/words/test/TestWordsObject.java
@@ -24,10 +24,10 @@ public class TestWordsObject {
 	
 	@Test
 	public void executeNextActionShouldExecuteNextMoveAction() {
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.RIGHT), new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.RIGHT), new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.LEFT), new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.LEFT), new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
 		
 		try {
 			obj.executeNextAction(null);
@@ -97,12 +97,12 @@ public class TestWordsObject {
 	
 	@Test
 	public void enqeueAtFrontShouldBeNextActionExecuted() {
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.RIGHT), new LNodeNum(3)));
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.UP), new LNodeNum(5)));
-		obj.enqueueAction(new MoveAction(new Direction(Direction.Type.DOWN), new LNodeNum(5)));
+		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(3)));
+		obj.enqueueAction(new MoveAction(Direction.Type.UP, new LNodeNum(5)));
+		obj.enqueueAction(new MoveAction(Direction.Type.DOWN, new LNodeNum(5)));
 		
 		// This should be first to be executed
-		obj.enqueueActionAtFront(new MoveAction(new Direction(Direction.Type.LEFT), new LNodeNum(1)));
+		obj.enqueueActionAtFront(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
 		
 		try {
 			obj.executeNextAction(null);


### PR DESCRIPTION
This branch does a slight refactor of the Direction class.  Previously, a Direction was an object that could be instantiated.  This actually could create some subtle problems when we flip a direction in a move because the value was negative, but the original LNodeDirection still has a handle to it.  (I encountered this as a subtle bug when experimenting with a Marco Polo sample program).  That could be fixed by always copying the Direction object when creating a new one, but I think the approach on this branch is safer and clearer.  Now, there is no Direction object per se.  The Direction class simply provides a static enum with the different directions.

This branch also has a minor unrelated bug fix in WordsObject.setProperty(), where after we set the row or column, it should exit, whereas previously is would go on to actually set a property called row or column.  (It never had any adverse effect, because the getProperty() method would always retrieve the current row or column.)
