### PR TITLE
Refactor Direction to not use Type

### DIFF
--- a/src/words/Words.y
+++ b/src/words/Words.y
@@ -302,11 +302,11 @@ queue_assign_property:
 	;
 
 direction:
-		ANYWHERE									{ $$ = new LNodeDirection(Direction.Type.ANYWHERE); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	DOWN										{ $$ = new LNodeDirection(Direction.Type.DOWN); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	LEFT										{ $$ = new LNodeDirection(Direction.Type.LEFT); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	RIGHT										{ $$ = new LNodeDirection(Direction.Type.RIGHT); ((AST) $$).lineNumber = lexer.lineNumber; }
-	|	UP											{ $$ = new LNodeDirection(Direction.Type.UP); ((AST) $$).lineNumber = lexer.lineNumber; }
+		ANYWHERE									{ $$ = new LNodeDirection(Direction.ANYWHERE); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	DOWN										{ $$ = new LNodeDirection(Direction.DOWN); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	LEFT										{ $$ = new LNodeDirection(Direction.LEFT); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	RIGHT										{ $$ = new LNodeDirection(Direction.RIGHT); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	UP											{ $$ = new LNodeDirection(Direction.UP); ((AST) $$).lineNumber = lexer.lineNumber; }
 	;
 
 now:

--- a/src/words/ast/ASTValue.java
+++ b/src/words/ast/ASTValue.java
@@ -22,7 +22,7 @@ public class ASTValue {
 	public double numValue;
 	public String stringValue;
 	public WordsObject objValue;
-	public Direction.Type directionValue;
+	public Direction directionValue;
 	public Position positionValue;
 	
 	public ASTValue(boolean b) {
@@ -45,7 +45,7 @@ public class ASTValue {
 		this.objValue = obj;
 	}
 	
-	public ASTValue(Direction.Type d) {
+	public ASTValue(Direction d) {
 		this.type = Type.DIRECTION;
 		this.directionValue = d;
 	}

--- a/src/words/ast/INodeMovesPredicate.java
+++ b/src/words/ast/INodeMovesPredicate.java
@@ -31,7 +31,7 @@ public class INodeMovesPredicate extends INodeBasicActionPredicate {
 			Action lastAction = object.getLastAction();
 			if (lastAction instanceof MoveAction) {
 				MoveAction lastMove = (MoveAction) lastAction;
-				if (moveDirection == null || moveDirection.directionValue == Direction.Type.ANYWHERE 
+				if (moveDirection == null || moveDirection.directionValue == Direction.ANYWHERE 
 						|| moveDirection.directionValue.equals(lastMove.getDirection())) {
 					returnVal.booleanValue = true;
 					environment.enterNewLocalScope();

--- a/src/words/ast/LNodeDirection.java
+++ b/src/words/ast/LNodeDirection.java
@@ -6,9 +6,9 @@ import words.environment.*;
  * A syntax tree leaf node for a direction.
  */
 public class LNodeDirection extends LNode {
-	public Direction.Type direction;
+	public Direction direction;
 	
-	public LNodeDirection(Direction.Type d) {
+	public LNodeDirection(Direction d) {
 		super();
 		this.direction = d;
 	}

--- a/src/words/environment/Direction.java
+++ b/src/words/environment/Direction.java
@@ -5,24 +5,19 @@ import java.util.Random;
 /**
  * An orthogonal direction.
  */
-public class Direction {
-	/**
-	 * One of the four orthogonal directions or an indication that any direction is permitted.
-	 */
-	public static enum Type {
+public enum Direction {
 		ANYWHERE,
 		DOWN,
 		LEFT,
 		RIGHT,
-		UP
-	}
+		UP;
 	
-	public static Type[] explicit = {Type.DOWN, Type.LEFT, Type.RIGHT, Type.UP};
+	public static Direction[] explicit = {DOWN, LEFT, RIGHT, UP};
 
 	/**
 	 * Returns a random explicit direction, i.e., not ANYWHERE.
 	 */
-	public static Type getRandom() {
+	public static Direction getRandom() {
 		Random randomGenerator = new Random();
 		int randomInt = randomGenerator.nextInt(explicit.length);
 		return Direction.explicit[randomInt];		
@@ -31,16 +26,16 @@ public class Direction {
 	/**
 	 * Returns the opposite of a given direction.  Returns null if called with ANYWHERE.
 	 */
-	public static Type getOpposite(Type input) {
+	public static Direction getOpposite(Direction input) {
 		switch(input) {
 			case DOWN:
-				return Type.UP;
+				return Direction.UP;
 			case LEFT:
-				return Type.RIGHT;
+				return Direction.RIGHT;
 			case RIGHT:
-				return Type.LEFT;
+				return Direction.LEFT;
 			case UP:
-				return Type.DOWN;
+				return Direction.DOWN;
 			default:
 				break;
 		} 

--- a/src/words/environment/MoveAction.java
+++ b/src/words/environment/MoveAction.java
@@ -5,7 +5,7 @@ import words.exceptions.*;
 import words.ast.*;
 
 public class MoveAction extends Action {
-	private Direction.Type direction;
+	private Direction direction;
 	private AST distanceExpression;		// The expression whose value will be the number of moves to make; used only before the move has been expanded
 
 	/**
@@ -14,8 +14,8 @@ public class MoveAction extends Action {
 	 * 
 	 * distanceExpression may be null, in which case the WordsMove will be treated as a 1-unit move.
 	 */
-	public MoveAction(Direction.Type direction, AST distanceExpression) {
-		if (direction == Direction.Type.ANYWHERE) {
+	public MoveAction(Direction direction, AST distanceExpression) {
+		if (direction == Direction.ANYWHERE) {
 			this.direction = Direction.getRandom();
 		} else {
 			this.direction = direction;
@@ -23,14 +23,14 @@ public class MoveAction extends Action {
 		this.distanceExpression = distanceExpression;
 	}
 	
-	public Direction.Type getDirection() {
+	public Direction getDirection() {
 		return direction;
 	}
 
 	/**
 	 * Private constructor used to create a 1-unit move action.
 	 */
-	private MoveAction(Direction.Type direction) {
+	private MoveAction(Direction direction) {
 		this.direction = direction;
 		this.distanceExpression = null;
 	}

--- a/test/words/test/TestINode.java
+++ b/test/words/test/TestINode.java
@@ -24,9 +24,9 @@ public class TestINode {
 	
 	AST fredStringLeaf = new LNodeString("Fred");
 	AST georgeStringLeaf = new LNodeString("George");
-	AST leftDirectionLeaf = new LNodeDirection(Direction.Type.LEFT);
-	AST rightDirectionLeaf = new LNodeDirection(Direction.Type.RIGHT);
-	AST anywhereDirectionLeaf = new LNodeDirection(Direction.Type.ANYWHERE);
+	AST leftDirectionLeaf = new LNodeDirection(Direction.LEFT);
+	AST rightDirectionLeaf = new LNodeDirection(Direction.RIGHT);
+	AST anywhereDirectionLeaf = new LNodeDirection(Direction.ANYWHERE);
 	
 	AST moveFredLeft2 = new INodeQueueMove(nothingLeaf, fredStringLeaf, leftDirectionLeaf, twoLeaf, null);
 	AST moveGeorgeLeft2 = new INodeQueueMove(nothingLeaf, georgeStringLeaf, leftDirectionLeaf, twoLeaf, null);

--- a/test/words/test/TestWordsMove.java
+++ b/test/words/test/TestWordsMove.java
@@ -9,16 +9,16 @@ public class TestWordsMove extends TestINode {
     @Test
     public void testWorkingWordsMove() throws WordsRuntimeException, WordsProgramException {
         environment.createObject("Fred", "thing", new Position(0, 0));
-        Action action = new MoveAction(Direction.Type.LEFT, twoLeaf);
+        Action action = new MoveAction(Direction.LEFT, twoLeaf);
         action.expand(environment.getObject("Fred"), environment);
     }
 
     @Test (expected = WordsProgramException.class)
     public void onlyOperatesOnStringsAndNumbers() throws WordsRuntimeException, WordsProgramException {
         environment.createObject("Fred", "thing", new Position(0, 0));
-        Action action1 = new MoveAction(Direction.Type.LEFT, nothingLeaf);
+        Action action1 = new MoveAction(Direction.LEFT, nothingLeaf);
         action1.expand(environment.getObject("Fred"), environment);
-        Action action2 = new MoveAction(Direction.Type.LEFT, trueLeaf);
+        Action action2 = new MoveAction(Direction.LEFT, trueLeaf);
         action2.expand(environment.getObject("Fred"), environment);
     }
 

--- a/test/words/test/TestWordsObject.java
+++ b/test/words/test/TestWordsObject.java
@@ -24,10 +24,10 @@ public class TestWordsObject {
 	
 	@Test
 	public void executeNextActionShouldExecuteNextMoveAction() {
-		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
-		obj.enqueueAction(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.RIGHT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.RIGHT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.LEFT, new LNodeNum(1)));
+		obj.enqueueAction(new MoveAction(Direction.LEFT, new LNodeNum(1)));
 		
 		try {
 			obj.executeNextAction(null);
@@ -97,12 +97,12 @@ public class TestWordsObject {
 	
 	@Test
 	public void enqeueAtFrontShouldBeNextActionExecuted() {
-		obj.enqueueAction(new MoveAction(Direction.Type.RIGHT, new LNodeNum(3)));
-		obj.enqueueAction(new MoveAction(Direction.Type.UP, new LNodeNum(5)));
-		obj.enqueueAction(new MoveAction(Direction.Type.DOWN, new LNodeNum(5)));
+		obj.enqueueAction(new MoveAction(Direction.RIGHT, new LNodeNum(3)));
+		obj.enqueueAction(new MoveAction(Direction.UP, new LNodeNum(5)));
+		obj.enqueueAction(new MoveAction(Direction.DOWN, new LNodeNum(5)));
 		
 		// This should be first to be executed
-		obj.enqueueActionAtFront(new MoveAction(Direction.Type.LEFT, new LNodeNum(1)));
+		obj.enqueueActionAtFront(new MoveAction(Direction.LEFT, new LNodeNum(1)));
 		
 		try {
 			obj.executeNextAction(null);


### PR DESCRIPTION
Branched off Andrew's refactor of direction. By making "Direction" itself defined as an enum, we can get rid of that nasty ".Type" that had to be called every time we used direction. 

Note: This PR will merge into refactor-direction, not master. Then, once this is on refactor-direction (assuming you like it), we would merge Andrew's existing PR of refactor-direction into master. 
