### PR TITLE
Adjacency Predicates

### DIFF
--- a/src/words/Words.flex
+++ b/src/words/Words.flex
@@ -68,11 +68,13 @@ LEQ = "<="
 
 	/* Keywords */
 "A" | "a" | "An" | "an"			{ onMatch(); return Words.A; }
+"above"							{ onMatch(); return Words.ABOVE; }
 "and"							{ onMatch(); return Words.AND; }
 "anywhere"						{ onMatch(); return Words.ANYWHERE; }
 "As" | "as"						{ onMatch(); return Words.AS; }
 "at"							{ onMatch(); return Words.AT; }
 "be"							{ onMatch(); return Words.BE; }
+"below"							{ onMatch(); return Words.BELOW; }
 "can"							{ onMatch(); return Words.CAN; }
 "down"							{ onMatch(); return Words.DOWN; }
 "Exit"							{ onMatch(); return Words.EXIT; }
@@ -85,6 +87,7 @@ LEQ = "<="
 "move"							{ onMatch(); return Words.MOVE; }
 "moves"							{ onMatch(); return Words.MOVES; }
 "means"							{ onMatch(); return Words.MEANS; }
+"next"							{ onMatch(); return Words.NEXT; }
 "not"							{ onMatch(); return Words.NOT; }
 "nothing"						{ onMatch(); return Words.NOTHING; }
 "now"							{ onMatch(); return Words.NOW; }
@@ -99,6 +102,7 @@ LEQ = "<="
 "Stop"							{ onMatch(); return Words.STOP; }
 "then"							{ onMatch(); return Words.THEN; }
 "times"							{ onMatch(); return Words.TIMES; }
+"to"							{ onMatch(); return Words.TO; }
 "touches"						{ onMatch(); return Words.TOUCHES; }
 "up"							{ onMatch(); return Words.UP; }
 "wait"							{ onMatch(); return Words.WAIT; }

--- a/src/words/Words.y
+++ b/src/words/Words.y
@@ -7,11 +7,13 @@
 
 	/* Keyword-related tokens */
 %token A
+%token ABOVE
 %token AND
 %token ANYWHERE
 %token AS
 %token AT
 %token BE
+%token BELOW
 %token CAN
 %token DOWN
 %token EXIT
@@ -24,6 +26,7 @@
 %token MOVE
 %token MOVES
 %token MEANS
+%token NEXT
 %token NOT
 %token NOTHING
 %token NOW
@@ -38,6 +41,7 @@
 %token STOP
 %token THEN
 %token TIMES
+%token TO
 %token TOUCHES
 %token UP
 %token WAIT
@@ -92,6 +96,7 @@
 %type <obj> subject
 %type <obj> alias
 %type <obj> queue_assign_property
+%type <obj> adjacency_expression
 %type <obj> direction
 %type <obj> now
 %type <obj> position
@@ -223,6 +228,7 @@ basic_action_predicate:
 	|	subject alias SAYS value_expression											{ $$ = new INodeSaysPredicate($1, $2, $4); ((AST) $$).lineNumber = lexer.lineNumber; }
 	|	subject alias WAITS															{ $$ = new INodeWaitsPredicate($1, $2); ((AST) $$).lineNumber = lexer.lineNumber; }
 	|	subject alias TOUCHES subject alias											{ $$ = new INodeTouchesPredicate($1, $2, $4, $5); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	subject alias adjacency_expression subject alias							{ $$ = new INodeAdjacencyPredicate($1, $2, $3, $4, $5); ((AST) $$).lineNumber = lexer.lineNumber; }
 	;
 
 boolean_predicate:
@@ -299,6 +305,14 @@ alias:
 
 queue_assign_property:
 		identifier BE value_expression				{ $$ = new INodeQueueAssignProperty($1, $3); ((AST) $$).lineNumber = lexer.lineNumber; }
+	;
+
+adjacency_expression:
+		IS NEXT TO									{ $$ = new LNodeDirection(Direction.ANYWHERE); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	IS BELOW									{ $$ = new LNodeDirection(Direction.DOWN); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	IS LEFT OF									{ $$ = new LNodeDirection(Direction.LEFT); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	IS RIGHT OF									{ $$ = new LNodeDirection(Direction.RIGHT); ((AST) $$).lineNumber = lexer.lineNumber; }
+	|	IS ABOVE									{ $$ = new LNodeDirection(Direction.UP); ((AST) $$).lineNumber = lexer.lineNumber; }
 	;
 
 direction:

--- a/src/words/ast/INodeAdjacencyPredicate.java
+++ b/src/words/ast/INodeAdjacencyPredicate.java
@@ -1,0 +1,57 @@
+package words.ast;
+
+import java.util.HashSet;
+
+import words.environment.*;
+import words.exceptions.*;
+
+public class INodeAdjacencyPredicate extends INodeBasicActionPredicate {
+	public INodeAdjacencyPredicate(Object... children) {
+		super(children);
+	}
+	
+	@Override
+	public ASTValue eval(Environment environment) throws WordsRuntimeException {
+		assert false : "Cannot eval INodeAdjacentPredicate without inherited Statement List";
+		return null;
+	}
+
+	@Override
+	public ASTValue eval(Environment environment, Object inheritedStmts) throws WordsRuntimeException {
+		ASTValue subject1 = children.get(0).eval(environment);
+		ASTValue objectAlias1 = children.get(1).eval(environment);
+		ASTValue direction = children.get(2).eval(environment);
+		ASTValue subject2 = children.get(3).eval(environment);
+		ASTValue objectAlias2 = children.get(4).eval(environment);
+		
+		INodeStatementList stmtList = (INodeStatementList) inheritedStmts;
+		
+		if (objectAlias1.type.equals(ASTValue.Type.STRING) 
+				&& objectAlias2.type.equals(ASTValue.Type.STRING)
+				&& objectAlias1.stringValue.equals(objectAlias2.stringValue)) {
+			throw new AliasException("Aliases may not be named the same.");
+		}
+		
+		HashSet<WordsObject> objectsToCheck1 = getObjectsToCheck(subject1, environment);
+		HashSet<WordsObject> objectsToCheck2 = getObjectsToCheck(subject2, environment);
+		ASTValue returnVal = new ASTValue(false);
+		
+		for (WordsObject object1: objectsToCheck1) {
+			for (WordsObject object2: objectsToCheck2) {
+				if (object1 != object2 && object1.getCurrentPosition().isAdjacentOf(object2.getCurrentPosition(), direction.directionValue)) {
+					returnVal.booleanValue = true;
+					environment.enterNewLocalScope();
+					if (objectAlias1.type.equals(ASTValue.Type.STRING)) {
+						environment.addObjectToCurrentNameScope(objectAlias1.stringValue, object1);
+					}
+					if (objectAlias2.type.equals(ASTValue.Type.STRING)) {
+						environment.addObjectToCurrentNameScope(objectAlias2.stringValue, object2);
+					}
+					stmtList.eval(environment);
+					environment.exitLocalScope();
+				}
+			}
+		}
+		return returnVal;
+	}
+}

--- a/src/words/environment/Position.java
+++ b/src/words/environment/Position.java
@@ -26,4 +26,29 @@ public class Position {
 		Position otherPos = (Position) other;
 		return this.x == otherPos.x && this.y == otherPos.y;
 	}
+	
+	/**
+	 * Returns whether this position is adjacent to another position by a given direction.
+	 * The direction indicates which direction this position must be relative to the other position,
+	 * i.e., DOWN would mean this position is below the other position. 
+	 */
+	public boolean isAdjacentOf(Position otherPos, Direction direction) {
+		switch (direction) {
+			case ANYWHERE:
+				return (this.x == otherPos.x && Math.abs(this.y - otherPos.y) == 1) || ((this.y == otherPos.y && Math.abs(this.x - otherPos.x) == 1));
+			case DOWN:
+				return this.x == otherPos.x && this.y == otherPos.y - 1;
+			case LEFT:
+				return this.y == otherPos.y && this.x == otherPos.x - 1;
+			case RIGHT:
+				return this.y == otherPos.y && this.x == otherPos.x + 1;
+			case UP:
+				return this.x == otherPos.x && this.y == otherPos.y + 1;
+			default:
+				break;
+		}
+		
+		return false;
+	}
+
 }

--- a/test/words/test/TestWordsPosition.java
+++ b/test/words/test/TestWordsPosition.java
@@ -19,4 +19,18 @@ public class TestWordsPosition {
 		assertEquals("X position correctly rounded", pos.x, 2);
 		assertEquals("Y position correctly rounded", pos.y, 4);
 	}
+	
+	@Test
+	public void testAdjacency() {
+		Position posOther = new Position(2,4);
+		Position posLeft = new Position(1,4);
+		Position posRight = new Position(3,4);
+		Position posAbove = new Position(2,5);
+		Position posBelow = new Position(2,3);
+		
+		assertTrue("posLeft is left of posOther", posLeft.isAdjacentOf(posOther, Direction.LEFT));
+		assertTrue("posRight is right of posOther", posRight.isAdjacentOf(posOther, Direction.RIGHT));
+		assertTrue("posAbove is above of posOther", posAbove.isAdjacentOf(posOther, Direction.UP));
+		assertTrue("posBelow is below of posOther", posBelow.isAdjacentOf(posOther, Direction.DOWN));
+	}
 }


### PR DESCRIPTION
This branch plays with a new language construct where a listener can test if members of different classes are adjacent to one another (up down left right), not just on top of each other (the existing "touches" predicate).  We can discuss this at our next meeting.

Right now it only tests adjacency by one cell, but it could be extended to allow farther away interactions.

If we agree with this, the grammar in the reference manual will have to be updated accordingly.
