### PR TITLE
Make touches only fire when the objects move to touch

### DIFF
--- a/src/words/ast/INodeAdjacencyPredicate.java
+++ b/src/words/ast/INodeAdjacencyPredicate.java
@@ -38,7 +38,8 @@ public class INodeAdjacencyPredicate extends INodeBasicActionPredicate {
 		
 		for (WordsObject object1: objectsToCheck1) {
 			for (WordsObject object2: objectsToCheck2) {
-				if (object1 != object2 && object1.getCurrentPosition().isAdjacentOf(object2.getCurrentPosition(), direction.directionValue)) {
+				boolean objectsMoved = object1.getLastAction() instanceof MoveAction || object2.getLastAction() instanceof MoveAction;
+				if (object1 != object2 && objectsMoved && object1.getCurrentPosition().isAdjacentOf(object2.getCurrentPosition(), direction.directionValue)) {
 					returnVal.booleanValue = true;
 					environment.pushNewScope();
 					if (objectAlias1.type.equals(ASTValue.Type.STRING)) {

--- a/src/words/ast/INodeAdjacencyPredicate.java
+++ b/src/words/ast/INodeAdjacencyPredicate.java
@@ -38,7 +38,8 @@ public class INodeAdjacencyPredicate extends INodeBasicActionPredicate {
 		
 		for (WordsObject object1: objectsToCheck1) {
 			for (WordsObject object2: objectsToCheck2) {
-				boolean objectsMoved = object1.getLastAction() instanceof MoveAction || object2.getLastAction() instanceof MoveAction;
+				boolean objectsMoved = object1.getLastAction() instanceof MoveAction || object2.getLastAction() instanceof MoveAction
+						|| object1.getLastAction() == null || object2.getLastAction() == null;
 				if (object1 != object2 && objectsMoved && object1.getCurrentPosition().isAdjacentOf(object2.getCurrentPosition(), direction.directionValue)) {
 					returnVal.booleanValue = true;
 					environment.pushNewScope();

--- a/src/words/ast/INodeSaysPredicate.java
+++ b/src/words/ast/INodeSaysPredicate.java
@@ -29,6 +29,9 @@ public class INodeSaysPredicate extends INodeBasicActionPredicate {
 		
 		for (WordsObject object : objectsToCheck) {
 			Action lastAction = object.getLastAction();
+			if (lastAction == null) {
+				continue;
+			}
 			if (lastAction instanceof SayAction && object.getCurrentMessage().equals(sayStatement.stringValue)) {
 				returnVal.booleanValue = true;
 				environment.pushNewScope();

--- a/src/words/ast/INodeTouchesPredicate.java
+++ b/src/words/ast/INodeTouchesPredicate.java
@@ -37,7 +37,8 @@ public class INodeTouchesPredicate extends INodeBasicActionPredicate {
 		
 		for (WordsObject object1: objectsToCheck1) {
 			for (WordsObject object2: objectsToCheck2) {
-				if (object1 != object2 && object1.getCurrentPosition().equals(object2.getCurrentPosition())) {
+				boolean objectsMoved = object1.getLastAction() instanceof MoveAction || object2.getLastAction() instanceof MoveAction;
+				if (object1 != object2 && objectsMoved && object1.getCurrentPosition().equals(object2.getCurrentPosition())) {
 					returnVal.booleanValue = true;
 					environment.pushNewScope();
 					if (objectAlias1.type.equals(ASTValue.Type.STRING)) {

--- a/src/words/ast/INodeTouchesPredicate.java
+++ b/src/words/ast/INodeTouchesPredicate.java
@@ -37,7 +37,8 @@ public class INodeTouchesPredicate extends INodeBasicActionPredicate {
 		
 		for (WordsObject object1: objectsToCheck1) {
 			for (WordsObject object2: objectsToCheck2) {
-				boolean objectsMoved = object1.getLastAction() instanceof MoveAction || object2.getLastAction() instanceof MoveAction;
+				boolean objectsMoved = object1.getLastAction() instanceof MoveAction || object2.getLastAction() instanceof MoveAction
+						|| object1.getLastAction() == null || object2.getLastAction() == null;
 				if (object1 != object2 && objectsMoved && object1.getCurrentPosition().equals(object2.getCurrentPosition())) {
 					returnVal.booleanValue = true;
 					environment.pushNewScope();

--- a/src/words/ast/INodeWaitsPredicate.java
+++ b/src/words/ast/INodeWaitsPredicate.java
@@ -28,6 +28,9 @@ public class INodeWaitsPredicate extends INodeBasicActionPredicate {
 
 		for (WordsObject object : objectsToCheck) {
 			Action lastAction = object.getLastAction();
+			if (lastAction == null) {
+				continue;
+			}
 			if (lastAction instanceof WaitAction) {
 				returnVal.booleanValue = true;
 				environment.pushNewScope();

--- a/src/words/environment/Environment.java
+++ b/src/words/environment/Environment.java
@@ -142,9 +142,6 @@ public class Environment {
 				objectsByClass.put(wordsClass, newSet);
 			}
 			
-			// TODO: decide if this is appropriate (given that it could figure listeners)
-			newObject.enqueueAction(new WaitAction(getCurrentScope(), new LNodeNum(1)));
-			
 			return newObject;
 		} else {
 			throw new ObjectAlreadyExistsException(objectName);

--- a/src/words/environment/WordsObject.java
+++ b/src/words/environment/WordsObject.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
 
 import words.environment.Property.PropertyType;
 import words.exceptions.*;
@@ -21,6 +19,7 @@ public class WordsObject {
 	private Position cell;
 	private String currentMessage;
 	private Action lastAction;
+	private boolean createdInThisFrame;
 	
 	// While an object is expanding a custom action, actions are enqueued in a separate list
 	private boolean isExpandingCustomAction;
@@ -36,6 +35,7 @@ public class WordsObject {
 		this.customActionExpansion = new LinkedList<Action>();
 		this.isExpandingCustomAction = false;
 		this.referers = new HashMap<WordsObject, ArrayList<Property>>();
+		this.createdInThisFrame = true;
 	}
 	
 	public void clearActionQueue() {
@@ -172,17 +172,22 @@ public class WordsObject {
 	}
 
 	public void executeNextAction(Environment environment) throws WordsProgramException {
-		if (!actionQueue.isEmpty()) {
-			while (actionQueue.peek().isExpandable()) {
-				Action action = actionQueue.pop();
-				actionQueue.addAll(0, action.expand(this, environment));
-			}
-			
-			Action action = actionQueue.pop();
-			lastAction = action;
-			action.execute(this, environment);
+		if (createdInThisFrame) {
+			createdInThisFrame = false;
+			return;
 		} else {
-			lastAction = new WaitAction(environment.getCurrentScope());
+			if (!actionQueue.isEmpty()) {
+				while (actionQueue.peek().isExpandable()) {
+					Action action = actionQueue.pop();
+					actionQueue.addAll(0, action.expand(this, environment));
+				}
+				
+				Action action = actionQueue.pop();
+				lastAction = action;
+				action.execute(this, environment);
+			} else {
+				lastAction = new WaitAction(environment.getCurrentScope());
+			}
 		}
 	}
 

--- a/test/words/test/TestINode.java
+++ b/test/words/test/TestINode.java
@@ -34,6 +34,8 @@ public class TestINode {
 	AST moveFredRight2 = new INodeQueueMove(nothingLeaf, fredStringLeaf, rightDirectionLeaf, twoLeaf, null);
 	AST moveFredLeftNegative2 = new INodeQueueMove(nothingLeaf, fredStringLeaf, leftDirectionLeaf, negTwoLeaf, null);
 	AST moveFredAnywhere2 = new INodeQueueMove(nothingLeaf, fredStringLeaf, anywhereDirectionLeaf, twoLeaf, null);
+	AST makeFredWait1 = new INodeQueueWait(new INodeReferenceList(), fredStringLeaf, new LNodeNum(1.0), null);
+	AST makeGeorgeWait1 = new INodeQueueWait(new INodeReferenceList(), georgeStringLeaf, new LNodeNum(1.0), null);
 	
 	AST statementsAboutFred = new INodeStatementList(moveFredLeft2, moveFredRight2, moveFredAnywhere2);
 	

--- a/test/words/test/TestINodeTouchesPredicate.java
+++ b/test/words/test/TestINodeTouchesPredicate.java
@@ -19,11 +19,13 @@ public class TestINodeTouchesPredicate extends TestINode {
 		INodeTouchesPredicate touchesPred = new INodeTouchesPredicate(thingStringLeaf, new LNodeIdentifier("alias1"), 
 				thingStringLeaf, new LNodeIdentifier("alias2"));
 		
-		assertEquals("Two things in same location eval true", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
-		environment.getVariable("Fred").objProperty.moveDown();
+		assertEquals("Two things in same location eval false when haven't moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
+		loop.enqueueAST(moveFredLeft2);
+		loop.fastForwardEnvironment(1);
 		assertEquals("Two things not in same location eval false", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
-		environment.getVariable("George").objProperty.moveDown();
-		assertEquals("Two things in same location eval true", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
+		loop.enqueueAST(moveGeorgeLeft2);
+		loop.fastForwardEnvironment(2);
+		assertEquals("Two things in same location eval true when just moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
 	}
 	
 	@Test
@@ -51,11 +53,13 @@ public class TestINodeTouchesPredicate extends TestINode {
 		INodeTouchesPredicate touchesPred = new INodeTouchesPredicate(thingStringLeaf, new LNodeIdentifier("alias1"), 
 				thingStringLeaf, new LNodeIdentifier("alias2"));
 		
-		assertEquals("Two things in same location eval true", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
-		environment.getVariable("Fred").objProperty.moveDown();
+		assertEquals("Two things in same location eval false when haven't moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
+		loop.enqueueAST(moveFredLeft2);
+		loop.fastForwardEnvironment(1);
 		assertEquals("Two things not in same location eval false", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
-		environment.getVariable("George").objProperty.moveDown();
-		assertEquals("Two things in same location eval true", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
+		loop.enqueueAST(moveGeorgeLeft2);
+		loop.fastForwardEnvironment(2);
+		assertEquals("Two things in same location eval true when just moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
 	}
 
 }

--- a/test/words/test/TestINodeTouchesPredicate.java
+++ b/test/words/test/TestINodeTouchesPredicate.java
@@ -14,17 +14,20 @@ public class TestINodeTouchesPredicate extends TestINode {
 	public void knowsIfTwoThingsTouch() throws WordsRuntimeException {
 		environment.createObject("Fred", "thing", new Position(0,0));
 		environment.createObject("George", "thing", new Position(0,0));
-		loop.fastForwardEnvironment(1); //objects are created with a 1 frame wait, so use it up.
-		
 		INodeTouchesPredicate touchesPred = new INodeTouchesPredicate(thingStringLeaf, new LNodeIdentifier("alias1"), 
 				thingStringLeaf, new LNodeIdentifier("alias2"));
+		loop.fastForwardEnvironment(1); //objects are created with a 1 frame wait, so use it up.
+		assertEquals("Two things in same location eval true when first created", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
 		
+		loop.enqueueAST(makeFredWait1);
+		loop.enqueueAST(makeGeorgeWait1);
+		loop.fastForwardEnvironment(1);
 		assertEquals("Two things in same location eval false when haven't moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
 		loop.enqueueAST(moveFredLeft2);
 		loop.fastForwardEnvironment(1);
 		assertEquals("Two things not in same location eval false", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
 		loop.enqueueAST(moveGeorgeLeft2);
-		loop.fastForwardEnvironment(2);
+		loop.fastForwardEnvironment(1);
 		assertEquals("Two things in same location eval true when just moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
 	}
 	
@@ -52,13 +55,17 @@ public class TestINodeTouchesPredicate extends TestINode {
 		
 		INodeTouchesPredicate touchesPred = new INodeTouchesPredicate(thingStringLeaf, new LNodeIdentifier("alias1"), 
 				thingStringLeaf, new LNodeIdentifier("alias2"));
+		assertEquals("Two things in same location eval true when first created", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
 		
+		loop.enqueueAST(makeFredWait1);
+		loop.enqueueAST(makeGeorgeWait1);
+		loop.fastForwardEnvironment(1);
 		assertEquals("Two things in same location eval false when haven't moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
 		loop.enqueueAST(moveFredLeft2);
 		loop.fastForwardEnvironment(1);
 		assertEquals("Two things not in same location eval false", touchesPred.eval(environment, statementsAboutFred).booleanValue, false);
 		loop.enqueueAST(moveGeorgeLeft2);
-		loop.fastForwardEnvironment(2);
+		loop.fastForwardEnvironment(1);
 		assertEquals("Two things in same location eval true when just moved", touchesPred.eval(environment, statementsAboutFred).booleanValue, true);
 	}
 

--- a/test/words/test/TestWordsObject.java
+++ b/test/words/test/TestWordsObject.java
@@ -24,93 +24,61 @@ public class TestWordsObject {
 	}
 	
 	@Test
-	public void executeNextActionShouldExecuteNextMoveAction() {
+	public void executeNextActionShouldExecuteNextMoveAction() throws WordsProgramException {
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.RIGHT, new LNodeNum(1)));
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.RIGHT, new LNodeNum(1)));
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.LEFT, new LNodeNum(1)));
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.LEFT, new LNodeNum(1)));
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
+		// First use up a the fake wait that exists on new objects
+		obj.executeNextAction(environment);
 		
+		obj.executeNextAction(environment);
 		assertEquals("Object moved 1 to the right in total", obj.getCurrentPosition().x, startPos.x + 1);
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
-		
+		obj.executeNextAction(environment);
 		assertEquals("Object moved 2 to the right in total", obj.getCurrentPosition().x, startPos.x + 2);
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
-		
+		obj.executeNextAction(environment);
 		assertEquals("Object moved 1 to the right in total again", obj.getCurrentPosition().x, startPos.x + 1);
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
-		
+		obj.executeNextAction(environment);
 		assertEquals("Object is back at its starting position", obj.getCurrentPosition().x, startPos.x);
 	}
 	
 	@Test
-	public void executeNextActionShouldExecuteNextSayAction() {
+	public void executeNextActionShouldExecuteNextSayAction() throws WordsProgramException {
 		// This line will need to be changed when WordsSay is updated to take an AST expression
 		obj.enqueueAction(new SayAction(new Scope(null), new LNodeString("first")));
 		obj.enqueueAction(new SayAction(new Scope(null), new LNodeString("second")));
 		obj.enqueueAction(new SayAction(new Scope(null), new LNodeString("third")));
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
+		// First use up a the fake wait that exists on new objects
+		obj.executeNextAction(environment);
 		
+		obj.executeNextAction(environment);
 		assertEquals("Object's message is first message", obj.getCurrentMessage(), "first");
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
-		
+		obj.executeNextAction(environment);
 		assertEquals("Object's message is second message", obj.getCurrentMessage(), "second");
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
-		
+		obj.executeNextAction(environment);
 		assertEquals("Object's message is third message", obj.getCurrentMessage(), "third");
 	}
 	
 	
 	@Test
-	public void enqeueAtFrontShouldBeNextActionExecuted() {
+	public void enqeueAtFrontShouldBeNextActionExecuted() throws WordsProgramException {
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.RIGHT, new LNodeNum(3)));
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.UP, new LNodeNum(5)));
 		obj.enqueueAction(new MoveAction(new Scope(null), Direction.DOWN, new LNodeNum(5)));
 		
+		// First use up a the fake wait that exists on new objects
+		obj.executeNextAction(environment);
 		// This should be first to be executed
 		obj.enqueueActionAtFront(new MoveAction(new Scope(null), Direction.LEFT, new LNodeNum(1)));
 		
-		try {
-			obj.executeNextAction(environment);
-		} catch (Exception e) {
-			fail();
-		}
-		
+		obj.executeNextAction(environment);
 		assertEquals("Object moved 1 to the left", obj.getCurrentPosition().x, startPos.x - 1);
 	}
 	


### PR DESCRIPTION
Andrew realized that our current definition of touches did not reconcile with the reference manual. When two objects touch, they should fire an event listener for "touches." If they have been standing on the same spot, they should not fire. 
