### PR TITLE
Fix INodeEquals Bug

### DIFF
--- a/src/words/ast/INodeEquals.java
+++ b/src/words/ast/INodeEquals.java
@@ -29,9 +29,8 @@ public class INodeEquals extends INode {
 			return new ASTValue(false);
 		}
 		
-		if ((lhs.type == ASTValue.Type.OBJ && rhs.type == ASTValue.Type.OBJ) &&
-			(lhs.objValue == rhs.objValue)) {
-			return new ASTValue(true);
+		if (lhs.type == ASTValue.Type.OBJ && rhs.type == ASTValue.Type.OBJ) {
+			return new ASTValue(lhs.objValue == rhs.objValue);
 		}
 		
 		// Remaining types must be a number or string

--- a/test/words/test/TestINode.java
+++ b/test/words/test/TestINode.java
@@ -47,6 +47,7 @@ public class TestINode {
 	AST falseLeaf = new INodeEquals(nothingLeaf, numLeaf);
 	
 	AST createObjectFred = new INodeCreateObject(fredStringLeaf, thingStringLeaf, null, position00);
+	AST createObjectGeorge = new INodeCreateObject(georgeStringLeaf, thingStringLeaf, null, position00);
 	
 	@Test
 	public void canAddNullToINode() {

--- a/test/words/test/TestINodeEquals.java
+++ b/test/words/test/TestINodeEquals.java
@@ -97,4 +97,23 @@ public class TestINodeEquals extends TestINode {
 		assertEquals("Creates a boolean", result.type, ASTValue.Type.BOOLEAN);
 		assertFalse("Result is false", result.booleanValue);
 	}
+	
+	@Test
+	public void objectShouldEqualItself() throws WordsRuntimeException {
+		createObjectFred.eval(environment);		
+		INode testNode = new INodeEquals(new INodeReferenceList(fredStringLeaf), new INodeReferenceList(fredStringLeaf));
+		ASTValue result = testNode.eval(environment);
+		assertEquals("Creates a boolean", result.type, ASTValue.Type.BOOLEAN);
+		assertTrue("Result is true", result.booleanValue);
+	}
+	
+	@Test
+	public void objectShouldNotEqualAnotherObject() throws WordsRuntimeException {
+		createObjectFred.eval(environment);
+		createObjectGeorge.eval(environment);
+		INode testNode = new INodeEquals(new INodeReferenceList(fredStringLeaf), new INodeReferenceList(georgeStringLeaf));
+		ASTValue result = testNode.eval(environment);
+		assertEquals("Creates a boolean", result.type, ASTValue.Type.BOOLEAN);
+		assertFalse("Result is false", result.booleanValue);
+	}
 }


### PR DESCRIPTION
I discovered a bug in INodeEquals where if two objects were being compared and they were not equal, it failed to return false.  This branch fixes that and includes system tests for it.
