### PR TITLE
Fix Argument Evaluation

### DIFF
--- a/src/words/ast/INodeArgument.java
+++ b/src/words/ast/INodeArgument.java
@@ -1,7 +1,5 @@
 package words.ast;
 
-import java.util.HashSet;
-
 import words.environment.*;
 import words.exceptions.*;
 
@@ -18,14 +16,10 @@ public class INodeArgument extends INode {
 	
 	@Override
 	public ASTValue eval(Environment environment, Object inherited) throws WordsRuntimeException {
-		@SuppressWarnings("unchecked")
-		HashSet<String> parameters = (HashSet<String>) inherited;
+		Scope evaluatedArguments = (Scope) inherited;
 		ASTValue argumentName = children.get(0).eval(environment);
-		
-		if (parameters.contains(argumentName.stringValue)) {
-			ASTValue argumentValue = children.get(1).eval(environment);
-			environment.addToCurrentScope(argumentName.stringValue, argumentValue.toWordsProperty());
-		}
+		ASTValue argumentValue = children.get(1).eval(environment);
+		evaluatedArguments.variables.put(argumentName.stringValue, argumentValue.toWordsProperty());
 		
 		return null;
 	}

--- a/src/words/environment/CustomAction.java
+++ b/src/words/environment/CustomAction.java
@@ -27,9 +27,19 @@ public class CustomAction extends Action {
 
 	@Override
 	protected LinkedList<Action> doExpand(WordsObject object, Environment environment) throws WordsProgramException {
+		// Evaluate the arguments (in the current scope) that will be passed to the formal parameters
+		Scope evaluatedArguments = new Scope(null);
+		if (arguments != null) {
+			try {
+				arguments.eval(environment, evaluatedArguments);
+			} catch (WordsRuntimeException e) {
+				throw new WordsProgramException(arguments, e);
+			}
+		}
+		
 		// Set up the object so that new actions are enqueued on a temporary list rather than the main action queue
 		object.startExpandingCustomAction();
-		actionDefinition.invoke(environment, object, arguments);
+		actionDefinition.invoke(environment, object, evaluatedArguments);
 		return object.finishExpandingCustomAction();
 	}
 }

--- a/src/words/environment/CustomActionDefinition.java
+++ b/src/words/environment/CustomActionDefinition.java
@@ -26,7 +26,7 @@ public class CustomActionDefinition {
 	 * Invoke this custom action definition on a given object using a given list of arguments.
 	 * Arguments may be null if there are no arguments.
 	 */
-	public void invoke(Environment environment, WordsObject object, AST arguments) throws WordsProgramException {
+	public void invoke(Environment environment, WordsObject object, Scope arguments) throws WordsProgramException {
 		// Custom action definitions can only appear in class definitions, which can only appear in the global scope
 		environment.pushNewScope(environment.getGlobalScope());
 		
@@ -37,8 +37,10 @@ public class CustomActionDefinition {
 		}
 
 		try {
-			if (arguments != null) {
-				arguments.eval(environment, parameters);
+			for (String argumentName : arguments.variables.keySet()) {
+				if (parameters.contains(argumentName)) {
+					environment.addToCurrentScope(argumentName, arguments.variables.get(argumentName));
+				}
 			}
 			
 			statementList.eval(environment);

--- a/system_test/CustomActionTest.words
+++ b/system_test/CustomActionTest.words
@@ -17,6 +17,11 @@ Fred is a man at 0,0.
 Make Fred say "I will jump.".
 Make Fred jump.
 Make Fred say "I jumped!".
-Make Fred say "I will sprint.".
-Make Fred sprint with distance 4, message "I'm sprinting!".
-Make Fred say "I sprinted!".
+
+If 1 = 1 then {
+	Bob is a man at -2, -2.
+	Bob's value is 4.
+	Make Fred say "I will sprint.".
+	Make Fred sprint with distance Bob's value, message "I'm sprinting!".
+	Make Fred say "I sprinted!".
+}

--- a/system_test/CustomActionTest.words.log
+++ b/system_test/CustomActionTest.words.log
@@ -1,300 +1,500 @@
 frame #: 1
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred
 frame #: 2
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I will jump."
 frame #: 3
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I'm jumping!"
 frame #: 4
+(-2,-2):
+<man> Bob
 (0,1):
 <man> Fred "I'm jumping!"
 frame #: 5
+(-2,-2):
+<man> Bob
 (0,2):
 <man> Fred "I'm jumping!"
 frame #: 6
+(-2,-2):
+<man> Bob
 (0,1):
 <man> Fred "I'm jumping!"
 frame #: 7
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I'm jumping!"
 frame #: 8
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I jumped!"
 frame #: 9
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I will sprint."
 frame #: 10
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I'm sprinting!"
 frame #: 11
+(-2,-2):
+<man> Bob
 (1,0):
 <man> Fred "I'm sprinting!"
 frame #: 12
+(-2,-2):
+<man> Bob
 (2,0):
 <man> Fred "I'm sprinting!"
 frame #: 13
+(-2,-2):
+<man> Bob
 (3,0):
 <man> Fred "I'm sprinting!"
 frame #: 14
+(-2,-2):
+<man> Bob
 (4,0):
 <man> Fred "I'm sprinting!"
 frame #: 15
+(-2,-2):
+<man> Bob
 (3,0):
 <man> Fred "I'm sprinting!"
 frame #: 16
+(-2,-2):
+<man> Bob
 (2,0):
 <man> Fred "I'm sprinting!"
 frame #: 17
+(-2,-2):
+<man> Bob
 (1,0):
 <man> Fred "I'm sprinting!"
 frame #: 18
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I'm sprinting!"
 frame #: 19
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 20
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 21
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 22
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 23
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 24
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 25
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 26
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 27
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 28
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 29
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 30
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 31
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 32
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 33
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 34
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 35
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 36
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 37
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 38
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 39
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 40
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 41
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 42
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 43
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 44
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 45
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 46
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 47
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 48
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 49
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 50
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 51
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 52
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 53
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 54
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 55
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 56
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 57
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 58
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 59
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 60
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 61
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 62
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 63
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 64
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 65
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 66
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 67
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 68
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 69
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 70
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 71
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 72
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 73
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 74
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 75
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 76
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 77
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 78
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 79
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 80
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 81
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 82
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 83
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 84
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 85
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 86
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 87
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 88
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 89
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 90
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 91
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 92
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 93
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 94
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 95
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 96
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 97
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 98
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 99
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"
 frame #: 100
+(-2,-2):
+<man> Bob
 (0,0):
 <man> Fred "I sprinted!"


### PR DESCRIPTION
This branch fixes a bug in the evaluation of arguments to custom actions.  Previously, the arguments were incorrectly being evaluated _after_ we have already moved into the scope of the custom action definition.  Instead, the arguments need to be evaluated in the scope of the caller, and then the _values_ have to be passed and installed in the custom action definition's scope.

I've modified the system test to catch this case in the future.
