### PR TITLE
Additional Pronouns

### DIFF
--- a/src/words/Words.flex
+++ b/src/words/Words.flex
@@ -113,12 +113,16 @@ LEQ = "<="
 "with"							{ onMatch(); return Words.WITH; }
 
 	/* Other lexemes */
-{IDENTIFIER} 	{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.IDENTIFIER; }
 "her" 			{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
 "his" 			{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
 "its" 			{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
 "their" 		{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
+"Her" 			{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
+"His" 			{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
+"Its" 			{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
+"Their" 		{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
 {REFERENCE} 	{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.REFERENCE; }
+{IDENTIFIER} 	{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.IDENTIFIER; }
 {NUM}			{ onMatch(); yyparser.yylval = new WordsVal(Double.parseDouble(yytext())); return Words.NUM; }
 {STRING}		{ onMatch(); yyparser.yylval = new WordsVal(yytext()); return Words.STRING; }
 

--- a/src/words/environment/CustomActionDefinition.java
+++ b/src/words/environment/CustomActionDefinition.java
@@ -31,7 +31,7 @@ public class CustomActionDefinition {
 		environment.pushNewScope(environment.getGlobalScope());
 		
 		// Install the pronouns to point to the given object
-		String[] pronouns = {"them", "it", "him", "her", "his", "its", "their"};
+		String[] pronouns = {"them", "it", "him", "her", "his", "its", "their", "Her", "His", "Its", "Their"};
 		for (String pronoun : pronouns) {
 			environment.addToCurrentScope(pronoun, new Property(object));
 		}


### PR DESCRIPTION
This branch fixes a minor issue with the pronouns that can serve as references (his, her, its, their).  Previously these pronouns only had lowercase forms, but they also need to have capitalized forms because they can appear as the first token in a statement (e.g., in a custom action definition, someone could write "Their property is 3.").

There was a also a bug in the lexer where the pronouns had lower priority than identifiers and so were not being tokenized correctly.
