### PR TITLE
GUI Left Right Flip

### DIFF
--- a/src/words/GUI.java
+++ b/src/words/GUI.java
@@ -198,9 +198,9 @@ public class GUI {
 			   } else if (e.getSource() == down) {
 				   yCenterCell -= moveStep;
 			   } else if (e.getSource() == left) {
-				   xCenterCell += moveStep;
-			   } else if (e.getSource() == right) {
 				   xCenterCell -= moveStep;
+			   } else if (e.getSource() == right) {
+				   xCenterCell += moveStep;
 			   } else if (e.getSource() == zoomIn) {
 				   numCells -= zoomStep;
 				   numCells = numCells < minCells ? minCells : numCells;


### PR DESCRIPTION
Previously pressing left/right in the GUI would scroll in the opposite direction of what I think is intuitive (and opposite conceptually of how the up/down buttons worked).
