### PR TITLE
Fix Position Creation

### DIFF
--- a/src/words/ast/INodePosition.java
+++ b/src/words/ast/INodePosition.java
@@ -21,6 +21,6 @@ public class INodePosition extends INode {
 			throw new InvalidTypeException(ASTValue.Type.NUM.toString(), col.type.toString());
 		}
 		
-		return new ASTValue(new Position(row.numValue, col.numValue));
+		return new ASTValue(new Position(col.numValue, row.numValue));
 	}
 }

--- a/system_test/BooleanListenerTest.words
+++ b/system_test/BooleanListenerTest.words
@@ -1,6 +1,6 @@
-Fred is a thing at 0,-5.
-John is a thing at 0,5.
-Kevin is a thing at 1,0.
+Fred is a thing at -5,0.
+John is a thing at 5,0.
+Kevin is a thing at 0,1.
 
 As long as Fred's row < 5 { Make Fred move up. }
 

--- a/system_test/ListenerTest.words
+++ b/system_test/ListenerTest.words
@@ -2,8 +2,8 @@ A person is a thing.
 A wall is a thing.
 
 Alex is a person at 0,0.
-Jon is a person at 2,1.
-wall1 is a wall at 1,0.
+Jon is a person at 1,2.
+wall1 is a wall at 0,1.
 
 Whenever a person [p] touches a wall [w] {
 	Make p say "ow".

--- a/system_test/LocalScopeIterationTest.words
+++ b/system_test/LocalScopeIterationTest.words
@@ -2,22 +2,22 @@ counter is a thing at -100,-100.
 counter's x is -5.
 counter's y is -5.
 Repeat 10 times {
-    wall is a thing at counter's x, counter's y.
+    wall is a thing at counter's y, counter's x.
     counter's x is counter's x + 1.
     Make wall move left 3.
 }
 Repeat 10 times {
-    wall is a thing at counter's x, counter's y.
+    wall is a thing at counter's y, counter's x.
     counter's y is counter's y + 1.
     Make wall move right 3.
 }
 Repeat 10 times {
-    wall is a thing at counter's x, counter's y.
+    wall is a thing at counter's y, counter's x.
     counter's x is counter's x - 1.
     Make wall move left 3.
 }
 Repeat 10 times {
-    wall is a thing at counter's x, counter's y.
+    wall is a thing at counter's y, counter's x.
     counter's y is counter's y - 1.
     Make wall move down 3.
 }

--- a/system_test/PropertiesTest.words
+++ b/system_test/PropertiesTest.words
@@ -2,7 +2,7 @@ Alex is a thing at 0,0.
 Alex's height is 6.2.
 Alex's weight is 200.
 
-Bob is a thing at 0,1.
+Bob is a thing at 1,0.
 Bob's height is 5.1.
 Alex's friend is Bob.
 

--- a/system_test/RemoveTest.words
+++ b/system_test/RemoveTest.words
@@ -5,9 +5,9 @@ Alex is a thing at 0,0.
 Remove Alex.
 
 Scott is a thing at 0,0.
-Dave is a thing at 0,1.
-Mark is a thing at 0,2.
-Dude is a thing at 0,3.
+Dave is a thing at 1,0.
+Mark is a thing at 2,0.
+Dude is a thing at 3,0.
 
 Scott's friend is Dave.
 Dave's brother is Mark.

--- a/system_test/ResetTest.words
+++ b/system_test/ResetTest.words
@@ -4,6 +4,6 @@ Make Alex say Alex's name.
 
 Reset.
 
-Bob is a thing at 0,1.
+Bob is a thing at 1,0.
 Bob's name is "bob".
 Make Bob say Bob's name.

--- a/test/words/test/TestINodePosition.java
+++ b/test/words/test/TestINodePosition.java
@@ -17,7 +17,7 @@ public class TestINodePosition extends TestINode {
 		INode testNode = new INodePosition(numLeaf1, numLeaf2);
 		ASTValue result = testNode.eval(environment);
 		assertEquals("Creates a position", result.type, ASTValue.Type.POSITION);
-		assertEquals("The position is the right position", result.positionValue, new Position(0,2));
+		assertEquals("The position is the right position", result.positionValue, new Position(2,0));
 	}
 	
 	@Test
@@ -28,7 +28,7 @@ public class TestINodePosition extends TestINode {
 		INode testNode = new INodePosition(numLeaf, stringLeaf);
 		ASTValue result = testNode.eval(environment);
 		assertEquals("Creates a position", result.type, ASTValue.Type.POSITION);
-		assertEquals("The position is the right position", result.positionValue, new Position(0,2));
+		assertEquals("The position is the right position", result.positionValue, new Position(2,0));
 	}
 	
 	@Test (expected = InvalidTypeException.class)


### PR DESCRIPTION
This branch fixes a bug in where objects are placed.

For an object creation statement like:
  Fred is a thing at 1,3.
the reference manual says 1 is the _row_ and 3 is the _column_.  Our Position class stores positions in terms of x and y, which means the row should be y and the column should be x.  However, INodePosition was creating Positions in reverse, where the row was assigned to x and the column to y.

The fix was simple, and the updates to the tests just involved swapping the values.  (Often, our tests use the same row and column, which is part of the reason why we hadn't noticed.  The other is that we may intuitively be thinking of positions as x,y, not row,column.)
