### PR TITLE
Fix Action Queue Null Pointer Exception

### DIFF
--- a/src/words/environment/WordsObject.java
+++ b/src/words/environment/WordsObject.java
@@ -176,6 +176,14 @@ public class WordsObject {
 			while (actionQueue.peek().isExpandable()) {
 				Action action = actionQueue.pop();
 				actionQueue.addAll(0, action.expand(this, environment));
+				
+				// If the action we just expanded was a custom action, it is possible that its expansion
+				// executed some immediate statements but caused no new actions to be enqueued
+				// In this case, we are done
+				if (actionQueue.isEmpty()) {
+					lastAction = new WaitAction(environment.getCurrentScope());
+					return;
+				}
 			}
 			
 			Action action = actionQueue.pop();


### PR DESCRIPTION
This branch fixes a bug in WordsObject executeNextAction() where it was possible to have a Null Pointer Exception.  When reading the diff, just look at executeNextAction() 186:191.  The rest are things are other pull requests that will be merged in separately.

The problem occured when a custom action definition included only immediate statements but no queueing statements.  For example, a class might have a custom action that, when invoked, simply changes some of the object's properties immediately.  If that custom action happened to be the last one on the object's queue, then action.expand() will return no new actions, the queue will be empty, and the call to actionQueue.peek() in the next iteration of the while loop will return null, so the call to isExpandable generates the exception.

The proposed solution is just to check inside the while loop whether the queue is empty, which could only arise if the expanded action was a custom action.  In that case, we can consider the last action to be a Wait, and we're done.
