### PR TITLE
Object Removal Fixes

### DIFF
--- a/src/words/FrameLoop.java
+++ b/src/words/FrameLoop.java
@@ -76,6 +76,8 @@ public class FrameLoop extends Thread {
 				System.out.println("> ");
 			}
 		}
+		
+		environment.cleanup();
 
 		// Phase 2: Action Queue Processing
 		for (WordsObject object : environment.getObjects()) {
@@ -87,6 +89,8 @@ public class FrameLoop extends Thread {
 				System.out.println("> ");
 			}
 		}
+		
+		environment.cleanup();
 
 		// Phase 3: Listener Evaluation
 		for (Iterator<WordsEventListener> iterator = environment.getEventListeners().iterator(); iterator.hasNext();) {
@@ -101,6 +105,8 @@ public class FrameLoop extends Thread {
 				System.out.println("> ");
 			}
 		}
+		
+		environment.cleanup();
 
 		if (GUI != null) {
 			GUI.clear();

--- a/src/words/ast/INodeRemoveObject.java
+++ b/src/words/ast/INodeRemoveObject.java
@@ -1,7 +1,6 @@
 package words.ast;
 
 import words.environment.*;
-import words.environment.Property.PropertyType;
 import words.exceptions.*;
 
 public class INodeRemoveObject extends INode {
@@ -25,7 +24,7 @@ public class INodeRemoveObject extends INode {
 			}
 		}
 		
-		environment.removeObject(obj);
+		obj.prepareForRemoval();
 		
 		return null;
 	}

--- a/src/words/environment/Environment.java
+++ b/src/words/environment/Environment.java
@@ -1,6 +1,7 @@
 package words.environment;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -153,14 +154,11 @@ public class Environment {
 	
 	public void removeObject(WordsObject object) {
 		object.clearReferers();
+		objectsByClass.get(object.getWordsClass()).remove(object);
 		
 		for (Scope scope : stack) {
-			if (scope.variables.remove(object.getObjectName()) != null) {
-				break;
-			}
+			scope.variables.values().removeAll(Collections.singleton(object));
 		}
-		
-		objectsByClass.get(object.getWordsClass()).remove(object);
 	}
 	
 	/**

--- a/src/words/environment/Environment.java
+++ b/src/words/environment/Environment.java
@@ -3,6 +3,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 
 import words.exceptions.*;
@@ -161,6 +162,20 @@ public class Environment {
 		}
 		
 		objectsByClass.get(object.getWordsClass()).remove(object);
+	}
+	
+	/**
+	 * Removes objects that have been flagged for removal.
+	 */
+	public void cleanup() {
+		for (Iterator<WordsObject> iterator = getObjects().iterator(); iterator.hasNext();) {
+			WordsObject obj = iterator.next();
+			
+			if (obj.shouldRemove()) {
+				iterator.remove();
+				removeObject(obj);
+			}
+		}
 	}
 	
 	/**

--- a/src/words/environment/Environment.java
+++ b/src/words/environment/Environment.java
@@ -1,6 +1,7 @@
 package words.environment;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -151,14 +152,16 @@ public class Environment {
 	
 	public void removeObject(WordsObject object) {
 		object.clearReferers();
+		objectsByClass.get(object.getWordsClass()).remove(object);
 		
 		for (Scope scope : stack) {
-			if (scope.variables.remove(object.getObjectName()) != null) {
-				break;
+			for (Iterator<Property> iterator = scope.variables.values().iterator(); iterator.hasNext();) {
+				Property property = iterator.next();
+				if (property.type == Property.PropertyType.OBJECT && property.objProperty == object) {
+					iterator.remove();
+				}
 			}
 		}
-		
-		objectsByClass.get(object.getWordsClass()).remove(object);
 	}
 	
 	/**

--- a/src/words/environment/WordsObject.java
+++ b/src/words/environment/WordsObject.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.Set;
 
 import words.environment.Property.PropertyType;
 import words.exceptions.*;
@@ -21,6 +19,7 @@ public class WordsObject {
 	private Position cell;
 	private String currentMessage;
 	private Action lastAction;
+	private boolean shouldRemove;
 	
 	// While an object is expanding a custom action, actions are enqueued in a separate list
 	private boolean isExpandingCustomAction;
@@ -36,6 +35,7 @@ public class WordsObject {
 		this.customActionExpansion = new LinkedList<Action>();
 		this.isExpandingCustomAction = false;
 		this.referers = new HashMap<WordsObject, ArrayList<Property>>();
+		this.shouldRemove = false;
 	}
 	
 	public void clearActionQueue() {
@@ -153,6 +153,14 @@ public class WordsObject {
 			
 			it.remove();
 		}
+	}
+	
+	public void prepareForRemoval() {
+		shouldRemove = true;
+	}
+	
+	public boolean shouldRemove() {
+		return shouldRemove;
 	}
 	
 	public void moveUp() {

--- a/test/words/test/TestINodeRemove.java
+++ b/test/words/test/TestINodeRemove.java
@@ -21,6 +21,7 @@ public class TestINodeRemove extends TestINode {
 		
 		INodeRemoveObject removeObj = new INodeRemoveObject(refList, id);
 		removeObj.eval(environment);
+		loop.fastForwardEnvironment(1);
 		assertEquals("RemovedObject is nothing", environment.getVariable("Fred").type, Property.PropertyType.NOTHING);
 	}
 	
@@ -41,6 +42,7 @@ public class TestINodeRemove extends TestINode {
 		
 		INodeRemoveObject removeObj = new INodeRemoveObject(refList, id);
 		removeObj.eval(environment);
+		loop.fastForwardEnvironment(1);
 		assertEquals("RemovedObject is nothing", environment.getVariable("Mark").type, Property.PropertyType.NOTHING);
 
 	}
@@ -62,6 +64,7 @@ public class TestINodeRemove extends TestINode {
 		
 		INodeRemoveObject removeObj = new INodeRemoveObject(refList, id);
 		removeObj.eval(environment);
+		loop.fastForwardEnvironment(1);
 		
 		Property fredsNewFriend = fred.getProperty("friend");
 		assertEquals(fredsNewFriend.objProperty, null);


### PR DESCRIPTION
This branch includes two subtle bug fixes related to object removal.

First, it's possible for the statements in the body of a listener to remove an object (whether it be the object that triggered the listener or some other object).  For listeners based on classes (e.g., "Whenever a thing moves"), the associated INode (say, INodeMovesPredicate) iterates through all of the matching objects.  If an object in the class gets removed by the listener's statement list, then we get a ConcurrentModificationException.  The proposed solution is to flag objects for removal and then remove them after each frame loop phase.  The prepareForRemoval() WordsObject method sets the flag, and the cleanup() method in Environment removes all objects that were flagged.

Second, there was a subtle bug in removeObject() in Environment.  Previously, it was removing an object by looking it up in the stack using the object's name.  The problem is, an object may also appear in the stack using an alias (such as inside a listener or custom action definition).  I've changed it to look it up by value (the object itself) and remove all instances anywhere in the stack.
