### PR TITLE
Remove Missing Object Bugfix

### DIFF
--- a/src/words/ast/INodeRemoveObject.java
+++ b/src/words/ast/INodeRemoveObject.java
@@ -14,16 +14,20 @@ public class INodeRemoveObject extends INode {
 		ASTValue refList = children.get(0).eval(environment);
 		ASTValue id = children.get(1).eval(environment);
 		
+		Property property;
 		if (refList.type == ASTValue.Type.NOTHING) {
-			obj = environment.getVariable(id.stringValue).objProperty;
+			property = environment.getVariable(id.stringValue);
+			if (property.type != Property.PropertyType.OBJECT) {
+				throw new ObjectNotFoundException(id.stringValue);
+			}
 		} else {
-			Property property = refList.objValue.getProperty(id.stringValue);
-			obj = property.objProperty;
-			if (obj == null) {
+			property = refList.objValue.getProperty(id.stringValue);
+			if (property.type != Property.PropertyType.OBJECT) {
 				throw new ReferenceException(id.stringValue, property.type);
 			}
 		}
 		
+		obj = property.objProperty;
 		obj.prepareForRemoval();
 		
 		return null;

--- a/test/words/test/TestINodeRemove.java
+++ b/test/words/test/TestINodeRemove.java
@@ -24,6 +24,17 @@ public class TestINodeRemove extends TestINode {
 		loop.fastForwardEnvironment(1);
 		assertEquals("RemovedObject is nothing", environment.getVariable("Fred").type, Property.PropertyType.NOTHING);
 	}
+
+	@Test (expected = ObjectNotFoundException.class)
+	public void testRemoveMissingObject() throws WordsRuntimeException {
+		assertEquals("Variable does not exist", environment.getVariable("Garbage").type, Property.PropertyType.NOTHING);
+		
+		INodeReferenceList refList = new INodeReferenceList();
+		LNodeIdentifier id = new LNodeIdentifier("Garbage");
+		
+		INodeRemoveObject removeObj = new INodeRemoveObject(refList, id);
+		removeObj.eval(environment);
+	}
 	
 	@Test
 	public void testRemoveReferersProperty() throws WordsRuntimeException {


### PR DESCRIPTION
Now shows an appropriate error if attempting to remove an object that does not exist.  Includes unit test for it.

Closes #133 
